### PR TITLE
Lock screen orientation to portrait mode

### DIFF
--- a/unischedule/android/app/src/main/AndroidManifest.xml
+++ b/unischedule/android/app/src/main/AndroidManifest.xml
@@ -13,15 +13,16 @@
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustResize"
+            android:screenOrientation="portrait"> <!-- Línea agregada para bloquear la orientación en modo retrato -->
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user
                  while the Flutter UI initializes. After that, this theme continues
                  to determine the Window background behind the Flutter UI. -->
             <meta-data
-              android:name="io.flutter.embedding.android.NormalTheme"
-              android:resource="@style/NormalTheme"
-              />
+                android:name="io.flutter.embedding.android.NormalTheme"
+                android:resource="@style/NormalTheme"
+                />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/unischedule/lib/main.dart
+++ b/unischedule/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:unischedule/routes/go_router_provider.dart';
 import 'package:unischedule/services/notifications_service.dart';
@@ -8,6 +9,11 @@ import 'package:timezone/data/latest.dart' as tz;
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
   NotificationService().initNotification();
+  WidgetsFlutterBinding.ensureInitialized();
+  SystemChrome.setPreferredOrientations([
+    DeviceOrientation.portraitUp,
+    DeviceOrientation.portraitDown,
+  ]);
   tz.initializeTimeZones();
 
   runApp(


### PR DESCRIPTION
Implemented a fix to lock the application's screen orientation to portrait mode. This was achieved by setting preferred orientations in the main function using the SystemChrome.setPreferredOrientations() method from the flutter/services.dart package.