### PR TITLE
Cache strategy for network Images: Profile Icons

### DIFF
--- a/unischedule/lib/presentation/friends_page/friends_page.dart
+++ b/unischedule/lib/presentation/friends_page/friends_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import '../../../providers/friends_page/friends_provider.dart';
 import 'package:unischedule/models/friends_page/friend_model.dart';
 import '../../../providers/friends_page/friends_state_notifier.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 
 void main() {
   runApp(ProviderScope(child: MaterialApp(home: const FriendsApp())));
@@ -111,12 +112,28 @@ Padding _buildSearchBar() {
       child: Row(
         children: [
           Padding(
-            padding: const EdgeInsets.all(2.0),
-            child: CircleAvatar(
-              radius: 26.5,
-              backgroundImage: NetworkImage(friend.profilePicture),
-            ),
-          ),
+              padding: const EdgeInsets.all(2.0),
+              child: CachedNetworkImage(
+                imageUrl: friend.profilePicture,
+                fadeInDuration: const Duration(milliseconds: 0),
+                fadeOutDuration: const Duration(milliseconds: 0),
+                filterQuality: FilterQuality.none,
+                maxHeightDiskCache: 100,
+                imageBuilder: (context, imageProvider) => CircleAvatar(
+                  radius: 26.5,
+                  backgroundImage: imageProvider,
+                ),
+                placeholder: (context, url) => const CircleAvatar(
+                  radius: 26.5,
+                  backgroundColor: Colors.white,
+                ),
+                errorWidget: (context, url, error) => const CircleAvatar(
+                  radius: 26.5,
+                  backgroundColor: Colors.white,
+                  child: Icon(Icons.error,
+                      color: Colors.red), // Error icon in white
+                ),
+              )),
           SizedBox(width: 16),
           Expanded(
             child: Text(

--- a/unischedule/lib/presentation/groups_page/groups_page.dart
+++ b/unischedule/lib/presentation/groups_page/groups_page.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import '../../../providers/groups_page/groups_provider.dart';
 import '../../../models/groups_page/group_model.dart';
 import '../../../providers/groups_page/groups_state_notifier.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 
 class GroupsPage extends ConsumerStatefulWidget {
   const GroupsPage({Key? key}) : super(key: key);
@@ -234,7 +235,26 @@ class ProfileIconsRow extends StatelessWidget {
                       width: 1,
                     ),
                   ),
-                  child: Image.network(imagePaths[i]),
+                  child: CachedNetworkImage(
+                    imageUrl: imagePaths[i],
+                    fadeInDuration: const Duration(milliseconds: 0),
+                    fadeOutDuration: const Duration(milliseconds: 0),
+                    filterQuality: FilterQuality.none,
+                    maxHeightDiskCache: 100,
+                    imageBuilder: (context, imageProvider) => CircleAvatar(
+                      radius: 20,
+                      backgroundImage: imageProvider,
+                    ),
+                    placeholder: (context, url) => const CircleAvatar(
+                      radius: 20,
+                      backgroundColor: Colors.white,
+                    ),
+                    errorWidget: (context, url, error) => const CircleAvatar(
+                      radius: 20,
+                      backgroundColor: Colors.white,
+                      child: Icon(Icons.error, color: Colors.red), // Error icon in white
+                    ),
+                  )
                 ),
               ),
             ),

--- a/unischedule/pubspec.yaml
+++ b/unischedule/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   sentry_flutter: ^7.18.0
   riverpod_generator: ^2.4.0
   flutter_rating_bar: ^4.0.1
+  cached_network_image:
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Implementation of Cache Strategy for network Images: Profile Images for now. This will help our eventual connectivity strategy for this views and also the performance and UX of those.

# Before

Here you can see a video of how it worked **before**:

**In this video you can see that before, the profile images had a longer loading time even when changing of view, also when disconnecting of internet, those images couldnt be retrieved again**

https://github.com/ISIS3510-202410-Team-13/Flutter/assets/69651671/7c7f60d5-1f97-4723-ae49-9dbc14a73c88

# Now

Here you can see a video of how it works **now**:

**Now the Profile Images are loaded very fast and doesnt have issues when changing of view, also are loaded even when the internet connection is losed**


https://github.com/ISIS3510-202410-Team-13/Flutter/assets/69651671/6cf5a051-091d-4665-8859-de29b0672e4b






close #89 