### PR TITLE
Create personal events

### DIFF
--- a/unischedule/lib/presentation/authentication_page/authentication_page.dart
+++ b/unischedule/lib/presentation/authentication_page/authentication_page.dart
@@ -12,6 +12,7 @@ import '../../../providers/friends_page/friends_state_notifier.dart';
 import '../../../providers/groups_page/groups_provider.dart';
 import '../../../providers/groups_page/groups_state_notifier.dart';
 import '../../../providers/events_page/events_provider.dart';
+import '../../../providers/events_page/events_state_notifier.dart';
 
 class AuthenticationPage extends StatefulWidget {
   const AuthenticationPage({Key? key}) : super(key: key);
@@ -147,6 +148,7 @@ class _AuthenticationPageState extends State<AuthenticationPage> {
       }
 
       var events = await ref.read(eventsProvider(userId).future);
+      ref.read(eventsStateNotifierProvider.notifier).setEvents(events);
       final boxEvents = await Hive.openBox<Event>('eventBox');
       boxEvents.clear();
       for (Event event in events) {

--- a/unischedule/lib/presentation/calendar_page/calendar_page.dart
+++ b/unischedule/lib/presentation/calendar_page/calendar_page.dart
@@ -1,4 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:unischedule/presentation/calendar_page/widgets/calendar_event.dart';
+
+import '../../../providers/events_page/events_state_notifier.dart';
 
 import 'widgets/calendar_background.dart';
 import 'widgets/calendar_time_lines.dart';
@@ -6,35 +10,47 @@ import 'widgets/calendar_app_bar.dart';
 import 'widgets/calendar_fab.dart';
 import 'widgets/calendar_week_days.dart';
 
-class CalendarApp extends StatefulWidget {
+class CalendarApp extends ConsumerStatefulWidget {
   const CalendarApp({Key? key}) : super(key: key);
 
   @override
   _CalendarAppState createState() => _CalendarAppState();
 }
 
-class _CalendarAppState extends State<CalendarApp> {
+class _CalendarAppState extends ConsumerState<CalendarApp> {
+
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
+
+    final personalEvents = ref.watch(eventsStateNotifierProvider);
+
+    return Scaffold(
       body: Stack(
         children: <Widget>[
-          CalendarAppBackground(),
-          CalendarFAB(),
+          const CalendarAppBackground(),
           Column(
             children: [
-              CalendarAppBar(),
+              const CalendarAppBar(),
               Expanded(
                 child: Padding(
-                  padding: EdgeInsets.fromLTRB(
-                      25, 0, 40, 0), // Margen aplicado solo a los lados
+                  padding: const EdgeInsets.symmetric(horizontal: 25, vertical: 0),
                   child: Column(
-                    mainAxisAlignment: MainAxisAlignment
-                        .start, // Alinea el contenido al inicio de la columna
                     children: [
-                      CalendarWeekDays(),
+                      const CalendarWeekDays(),
                       Expanded(
-                        child: CalendarTimeLines(),
+                        child: SingleChildScrollView(
+                          child: Stack(
+                            children: [
+                              const CalendarTimeLines(),
+                              ...personalEvents.map((e) => CalendarEvent(
+                                title: e.name,
+                                startDate: DateTime.fromMillisecondsSinceEpoch(e.startDate["_seconds"]! * 1000),
+                                endDate: DateTime.fromMillisecondsSinceEpoch(e.endDate["_seconds"]! * 1000),
+                                color: e.color,
+                              )).toList(),
+                            ],
+                          ),
+                        ),
                       ),
                     ],
                   ),
@@ -42,6 +58,7 @@ class _CalendarAppState extends State<CalendarApp> {
               ),
             ],
           ),
+          CalendarFAB(),
         ],
       ),
     );

--- a/unischedule/lib/presentation/calendar_page/widgets/calendar_event.dart
+++ b/unischedule/lib/presentation/calendar_page/widgets/calendar_event.dart
@@ -19,8 +19,8 @@ class CalendarEvent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
 
-    final startTime = '${startDate.toLocal().hour.toString()}:${startDate.toLocal().minute.toString()}';
-    final endTime = '${endDate.toLocal().hour.toString()}:${endDate.toLocal().minute.toString()}';
+    final startTime = '${startDate.toLocal().hour.toString()}:${startDate.toLocal().minute.toString().padLeft(2, '0')}';
+    final endTime = '${endDate.toLocal().hour.toString()}:${endDate.toLocal().minute.toString().padLeft(2, '0')}';
     final duration = endDate.difference(startDate).inMinutes / 60;
     final minutesSinceMidnight = startDate.toLocal().hour * 60 + startDate.toLocal().minute;
     final dayOfWeek = startDate.toLocal().weekday;

--- a/unischedule/lib/presentation/calendar_page/widgets/calendar_event.dart
+++ b/unischedule/lib/presentation/calendar_page/widgets/calendar_event.dart
@@ -1,0 +1,82 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+
+class CalendarEvent extends StatelessWidget {
+  const CalendarEvent({
+    super.key,
+    required this.title,
+    required this.startDate,
+    required this.endDate,
+    required this.color,
+  });
+
+  final String title;
+  final DateTime startDate;
+  final DateTime endDate;
+  final String color;
+
+  @override
+  Widget build(BuildContext context) {
+
+    final startTime = '${startDate.toLocal().hour.toString()}:${startDate.toLocal().minute.toString()}';
+    final endTime = '${endDate.toLocal().hour.toString()}:${endDate.toLocal().minute.toString()}';
+    final duration = endDate.difference(startDate).inMinutes / 60;
+    final minutesSinceMidnight = startDate.toLocal().hour * 60 + startDate.toLocal().minute;
+    final dayOfWeek = startDate.toLocal().weekday;
+    final dayOffset = dayOfWeek - 1;
+
+    final fullWidth = MediaQuery.of(context).size.width - 80; // 30 offset + (25 + 25) padding
+    const fullHeight = 24 * 70;  // Each hour 10 text + 60 sized box
+
+    final boxWidth = fullWidth / 7;
+    final boxHeight = fullHeight * duration / 24;
+
+    final topOffset = fullHeight * minutesSinceMidnight / 1440 + 6; // 6 sized box
+    final leftOffset = boxWidth * dayOffset + 30;  // 24 text + 6 sized box
+
+    final colorHex = int.parse("0xFF${color.substring(1)}");
+
+    return Positioned(
+      top: topOffset,
+      left: leftOffset,
+      child: Stack(
+        children: [
+          Container(
+            width: boxWidth,
+            height: boxHeight,
+            padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 15),
+            decoration: BoxDecoration(
+              color: Color(colorHex).withOpacity(0.7),
+              borderRadius: BorderRadius.circular(5),
+            ),
+            child: Center(
+              child: Text(
+                title,
+                style: const TextStyle(color: Colors.white, fontSize: 12),
+                maxLines: max(1, (duration * 2).floor()),  // NOTE this is empirical
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ),
+          Positioned(
+            top: 5,
+            left: 5,
+            child: Text(
+              startTime,
+              style: const TextStyle(color: Colors.white, fontSize: 6),
+            ),
+          ),
+          Positioned(
+            bottom: 5,
+            right: 5,
+            child: Text(
+              endTime,
+              style: const TextStyle(color: Colors.white, fontSize: 6),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/unischedule/lib/presentation/calendar_page/widgets/calendar_time_lines.dart
+++ b/unischedule/lib/presentation/calendar_page/widgets/calendar_time_lines.dart
@@ -5,314 +5,45 @@ class CalendarTimeLines extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Dimensiones para las cajas de eventos
-    final double boxHeight = 50; // Altura de dos horas (31px por hora)
-    final double boxWidth = MediaQuery.of(context).size.width -
-        80; // Ancho disponible menos el margen y la hora
-    return Stack(
-      children: [
-        // Lineas de tiempo estaticas
-        Column(
-          children: List.generate(10, (index) {
-            final time = 8 + index; // Horario inicial a las 8:00
-            return Padding(
-              padding: const EdgeInsets.symmetric(vertical: 25),
-              child: Row(
-                children: [
-                  SizedBox(
-                    child: Text(
-                      '$time:00',
-                      style: TextStyle(
-                        fontFamily: 'Poppins',
-                        fontSize: 8,
-                        fontWeight: FontWeight.normal,
-                        color: Colors.white,
-                      ),
-                    ),
-                  ),
-                  SizedBox(width: 10),
-                  Expanded(
-                    child: Divider(color: Colors.white, thickness: 0.6),
-                  ),
-                ],
-              ),
-            );
-          }),
-        ),
-        // Caja de evento
-        Positioned(
-          top: 34, // La altura de una hora desde las 8:00 (empieza en 8:00)
-          left: (boxWidth / 5) * 0 + 25, // Posición para el miércoles
-          child: Stack(
-            children: [
-              Container(
-                width: boxWidth / 5 - 10, // Ancho para el evento
-                height: boxHeight * 2, // Altura de dos horas
-                decoration: BoxDecoration(
-                  color: Color(0xFF8F98FF).withOpacity(0.7),
-                  borderRadius: BorderRadius.circular(5),
-                ),
-                child: Center(
-                  child: Text(
-                    'MOS',
-                    style: TextStyle(color: Colors.white, fontSize: 12),
-                  ),
-                ),
-              ),
-              Positioned(
-                top: 5,
-                left: 5,
-                child: Text(
-                  '8:00',
-                  style: TextStyle(color: Colors.white, fontSize: 6),
-                ),
-              ),
-              Positioned(
-                bottom: 5,
-                right: 5,
-                child: Text(
-                  '9:30',
-                  style: TextStyle(color: Colors.white, fontSize: 6),
-                ),
-              ),
-            ],
-          ),
-        ),
+    return Column(
+      children: List.generate(50, (index) {
 
-        Positioned(
-          top: 34, // La altura de una hora desde las 8:00 (empieza en 8:00)
-          left: (boxWidth / 5) * 2 + 25, // Posición para el miércoles
-          child: Stack(
-            children: [
-              Container(
-                width: boxWidth / 5 - 10, // Ancho para el evento
-                height: boxHeight * 2, // Altura de dos horas
-                decoration: BoxDecoration(
-                  color: Color(0xFF8F98FF).withOpacity(0.7),
-                  borderRadius: BorderRadius.circular(5),
-                ),
-                child: Center(
-                  child: Text(
-                    'MOS',
-                    style: TextStyle(color: Colors.white, fontSize: 12),
-                  ),
-                ),
-              ),
-              Positioned(
-                top: 5,
-                left: 5,
-                child: Text(
-                  '8:00',
-                  style: TextStyle(color: Colors.white, fontSize: 6),
-                ),
-              ),
-              Positioned(
-                bottom: 5,
-                right: 5,
-                child: Text(
-                  '9:30',
-                  style: TextStyle(color: Colors.white, fontSize: 6),
-                ),
-              ),
-            ],
-          ),
-        ),
+        if (index == 0) return const SizedBox(height: 6);
+        if (index % 2 == 0) return const SizedBox(height: 60);
 
-        Positioned(
-          top: 34, // La altura de una hora desde las 8:00 (empieza en 8:00)
-          left: (boxWidth / 5) * 4 + 25, // Posición para el miércoles
-          child: Stack(
-            children: [
-              Container(
-                width: boxWidth / 5 - 10, // Ancho para el evento
-                height: boxHeight * 2, // Altura de dos horas
-                decoration: BoxDecoration(
-                  color: Color(0xFF8F98FF).withOpacity(0.7),
-                  borderRadius: BorderRadius.circular(5),
-                ),
-                child: Center(
-                  child: Text(
-                    'MOS',
-                    style: TextStyle(color: Colors.white, fontSize: 12),
+        final time = '${(index-1)~/2}:00';
+        return Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Transform.translate(
+              offset: const Offset(0, -6),
+              child: SizedBox(
+                width: 24,
+                height: 10,
+                child: Text(
+                  time,
+                  style: const TextStyle(
+                    fontFamily: 'Poppins',
+                    fontSize: 8,
+                    fontWeight: FontWeight.normal,
+                    color: Colors.white,
                   ),
                 ),
               ),
-              Positioned(
-                top: 5,
-                left: 5,
-                child: Text(
-                  '8:00',
-                  style: TextStyle(color: Colors.white, fontSize: 6),
-                ),
+            ),
+            const SizedBox(width: 6),
+            const Expanded(
+              child: Divider(
+                color: Colors.white,
+                thickness: 0.6,
+                indent: 0.0,
+                endIndent: 0.0,
+                height: 0.6,
               ),
-              Positioned(
-                bottom: 5,
-                right: 5,
-                child: Text(
-                  '9:30',
-                  style: TextStyle(color: Colors.white, fontSize: 6),
-                ),
-              ),
-            ],
-          ),
-        ),
-
-        Positioned(
-          top: 231, // La altura de una hora desde las 8:00 (empieza en 8:00)
-          left: (boxWidth / 5) * 1 + 25, // Posición para el miércoles
-          child: Stack(
-            children: [
-              Container(
-                width: boxWidth / 5 - 10, // Ancho para el evento
-                height: boxHeight * 2, // Altura de dos horas
-                decoration: BoxDecoration(
-                  color: Color(0xFFFF7648).withOpacity(0.7),
-                  borderRadius: BorderRadius.circular(5),
-                ),
-                child: Center(
-                  child: Text(
-                    'LyM',
-                    style: TextStyle(color: Colors.white, fontSize: 12),
-                  ),
-                ),
-              ),
-              Positioned(
-                top: 5,
-                left: 5,
-                child: Text(
-                  '11:00',
-                  style: TextStyle(color: Colors.white, fontSize: 6),
-                ),
-              ),
-              Positioned(
-                bottom: 5,
-                right: 5,
-                child: Text(
-                  '12:30',
-                  style: TextStyle(color: Colors.white, fontSize: 6),
-                ),
-              ),
-            ],
-          ),
-        ),
-
-        Positioned(
-          top: 231, // La altura de una hora desde las 8:00 (empieza en 8:00)
-          left: (boxWidth / 5) * 3 + 25, // Posición para el miércoles
-          child: Stack(
-            children: [
-              Container(
-                width: boxWidth / 5 - 10, // Ancho para el evento
-                height: boxHeight * 2, // Altura de dos horas
-                decoration: BoxDecoration(
-                  color: Color(0xFFFF7648).withOpacity(0.7),
-                  borderRadius: BorderRadius.circular(5),
-                ),
-                child: Center(
-                  child: Text(
-                    'LyM',
-                    style: TextStyle(color: Colors.white, fontSize: 12),
-                  ),
-                ),
-              ),
-              Positioned(
-                top: 5,
-                left: 5,
-                child: Text(
-                  '11:00',
-                  style: TextStyle(color: Colors.white, fontSize: 6),
-                ),
-              ),
-              Positioned(
-                bottom: 5,
-                right: 5,
-                child: Text(
-                  '12:30',
-                  style: TextStyle(color: Colors.white, fontSize: 6),
-                ),
-              ),
-            ],
-          ),
-        ),
-
-        Positioned(
-          top: 429, // La altura de una hora desde las 8:00 (empieza en 8:00)
-          left: (boxWidth / 5) * 1 + 25, // Posición para el miércoles
-          child: Stack(
-            children: [
-              Container(
-                width: boxWidth / 5 - 10, // Ancho para el evento
-                height: boxHeight * 2, // Altura de dos horas
-                decoration: BoxDecoration(
-                  color: Color(0xFFFF7878).withOpacity(0.7),
-                  borderRadius: BorderRadius.circular(5),
-                ),
-                child: Center(
-                  child: Text(
-                    'DSW',
-                    style: TextStyle(color: Colors.white, fontSize: 12),
-                  ),
-                ),
-              ),
-              Positioned(
-                top: 5,
-                left: 5,
-                child: Text(
-                  '14:00',
-                  style: TextStyle(color: Colors.white, fontSize: 6),
-                ),
-              ),
-              Positioned(
-                bottom: 5,
-                right: 5,
-                child: Text(
-                  '15:30',
-                  style: TextStyle(color: Colors.white, fontSize: 6),
-                ),
-              ),
-            ],
-          ),
-        ),
-
-        Positioned(
-          top: 429, // La altura de una hora desde las 8:00 (empieza en 8:00)
-          left: (boxWidth / 5) * 4 + 25, // Posición para el miércoles
-          child: Stack(
-            children: [
-              Container(
-                width: boxWidth / 5 - 10, // Ancho para el evento
-                height: boxHeight * 2, // Altura de dos horas
-                decoration: BoxDecoration(
-                  color: Colors.blue.withOpacity(0.7),
-                  borderRadius: BorderRadius.circular(5),
-                ),
-                child: Center(
-                  child: Text(
-                    'Soccer',
-                    style: TextStyle(color: Colors.white, fontSize: 12),
-                  ),
-                ),
-              ),
-              Positioned(
-                top: 5,
-                left: 5,
-                child: Text(
-                  '14:00',
-                  style: TextStyle(color: Colors.white, fontSize: 6),
-                ),
-              ),
-              Positioned(
-                bottom: 5,
-                right: 5,
-                child: Text(
-                  '15:30',
-                  style: TextStyle(color: Colors.white, fontSize: 6),
-                ),
-              ),
-            ],
-          ),
-        ),
-      ],
+            ),
+          ],
+        );
+      }),
     );
   }
 }

--- a/unischedule/lib/presentation/calendar_page/widgets/calendar_week_days.dart
+++ b/unischedule/lib/presentation/calendar_page/widgets/calendar_week_days.dart
@@ -5,12 +5,12 @@ class CalendarWeekDays extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    List<String> days = ['M 26', 'T 27', 'W 28', 'T 29', 'F 01'];
+    List<String> days = ['M 26', 'T 27', 'W 28', 'T 29', 'F 01', 'S 02', 'S 03'];
     return Padding(
       padding: const EdgeInsets.only(
           top: 8.0,
           bottom: 8.0,
-          left: 20
+          left: 30.0
       ), // Espacio arriba y abajo para el padding
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceAround,

--- a/unischedule/lib/presentation/create-class_page/create-class_page.dart
+++ b/unischedule/lib/presentation/create-class_page/create-class_page.dart
@@ -9,12 +9,15 @@ import 'package:flutter_colorpicker/flutter_colorpicker.dart';
 
 import 'package:flutter_datetime_picker/flutter_datetime_picker.dart';
 import 'package:unischedule/models/create-class_page/create-class_model.dart';
+import 'package:unischedule/providers/events_page/events_state_notifier.dart';
 import 'package:unischedule/services/notifications_service.dart';
 import '../../../providers/create-class_page/create-class_provider.dart';
 import 'package:intl/intl.dart';
 
 import 'package:flutter_rating_bar/flutter_rating_bar.dart';
 
+import '';
+import '../../models/events_page/event_model.dart';
 
 class CreateClassPage extends ConsumerStatefulWidget {
   const CreateClassPage({Key? key}) : super(key: key);
@@ -27,7 +30,6 @@ class _CreateClassPageState extends ConsumerState<CreateClassPage> {
   DateTime _eventStartTime = DateTime.now();
   String _selectedDuration = '1 Hour'; // Valor inicial
   String? _selectedReminder;
-
 
   int _getReminderMinutes(String? reminder) {
     switch (reminder) {
@@ -43,17 +45,16 @@ class _CreateClassPageState extends ConsumerState<CreateClassPage> {
         return 0; // No reminder or unhandled value
     }
   }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Column(
-        children: <Widget>[
-          _buildAppBar(),
-          Expanded(
-            child: _buildCreateClassForm(),
-          ),
-        ]
-      ),
+      body: Column(children: <Widget>[
+        _buildAppBar(),
+        Expanded(
+          child: _buildCreateClassForm(),
+        ),
+      ]),
       backgroundColor: const Color(0xFFF8F8F8),
     );
   }
@@ -67,7 +68,8 @@ class _CreateClassPageState extends ConsumerState<CreateClassPage> {
         icon: SvgPicture.asset('assets/icons/arrow-left.svg',
             width: 21, height: 24, color: Colors.black),
         onPressed: () {
-          context.go('/calendar'); // FIXME - Pop last route, will need to work on navigation stack
+          context.go(
+              '/calendar'); // FIXME - Pop last route, will need to work on navigation stack
         },
       ),
       title: const Text(
@@ -84,23 +86,44 @@ class _CreateClassPageState extends ConsumerState<CreateClassPage> {
           icon: SvgPicture.asset('assets/icons/plus.svg',
               width: 24, height: 24, color: Colors.black),
           onPressed: () {
-
-            DateTime notificationTime = _eventStartTime.subtract(Duration(minutes: _getReminderMinutes(_selectedReminder)));
-            print('Hora notificacion: ${notificationTime} , minutos antes para el recordatorio:  ${Duration(minutes: _getReminderMinutes(_selectedReminder))} ');
+            DateTime notificationTime = _eventStartTime.subtract(
+                Duration(minutes: _getReminderMinutes(_selectedReminder)));
+            print(
+                'Hora notificacion: ${notificationTime} , minutos antes para el recordatorio:  ${Duration(minutes: _getReminderMinutes(_selectedReminder))} ');
             NotificationService().scheduleNotification(
                 title: 'Scheduled Event Reminder',
-                body: 'Your event is about to start at ${DateFormat('HH:mm').format(_eventStartTime)}',
+                body:
+                    'Your event is about to start at ${DateFormat('HH:mm').format(_eventStartTime)}',
                 scheduledNotificationDateTime: notificationTime);
+
+            ref.read(eventsStateNotifierProvider.notifier).addEvent(
+              // FIXME - This is a hardcoded event, will need to work on a form to create the event
+              Event(
+                id: '1',
+                color: '#9DCC18',
+                reminder: _getReminderMinutes(_selectedReminder),
+                endDate: {
+                  "_seconds": _eventStartTime.add(Duration(hours: 1)).millisecondsSinceEpoch ~/ 1000,
+                  "_nanoseconds": _eventStartTime.add(Duration(hours: 1)).microsecondsSinceEpoch * 1000,
+                },
+                name: 'Event Name',
+                description: 'Event Description',
+                startDate: {
+                  "_seconds": _eventStartTime.millisecondsSinceEpoch ~/ 1000,
+                  "_nanoseconds": _eventStartTime.microsecondsSinceEpoch * 1000,
+                },
+                labels: ['Uniandes 📚'],
+              ),
+            );
+
             context.go('/calendar');
           },
         ),
-
       ],
     );
   }
 
   Widget _buildCreateClassForm() {
-
     const assistants = <String>[
       'Laura',
       'Gotty',
@@ -108,7 +131,8 @@ class _CreateClassPageState extends ConsumerState<CreateClassPage> {
       'Juan',
       'Lucciano'
     ];
-    final MultiSelectController assistantsMultiSelectController = MultiSelectController();
+    final MultiSelectController assistantsMultiSelectController =
+        MultiSelectController();
 
     const reminders = <String>[
       'No reminder',
@@ -119,7 +143,6 @@ class _CreateClassPageState extends ConsumerState<CreateClassPage> {
       '1 hour before',
     ];
 
-
     const labels = <String>[
       'Uniandes 📚',
       'Work 👩‍💻',
@@ -127,460 +150,513 @@ class _CreateClassPageState extends ConsumerState<CreateClassPage> {
       'Family 👨‍👩‍👧‍👦',
       'Friends 👯‍',
     ];
-    final MultiSelectController labelsMultiSelectController = MultiSelectController();
+    final MultiSelectController labelsMultiSelectController =
+        MultiSelectController();
 
     var availableSpacesParams = ref.watch(availableSpacesParamsProvider);
-    _eventStartTime = DateTime(_eventStartTime.year, _eventStartTime.month, _eventStartTime.day, availableSpacesParams.startTime.hour, availableSpacesParams.startTime.minute);
-    _selectedDuration = '${availableSpacesParams.duration ~/ 60} Hour${availableSpacesParams.duration ~/ 60 > 1 ? 's' : ''}';
+    _eventStartTime = DateTime(
+        _eventStartTime.year,
+        _eventStartTime.month,
+        _eventStartTime.day,
+        availableSpacesParams.startTime.hour,
+        availableSpacesParams.startTime.minute);
+    _selectedDuration =
+        '${availableSpacesParams.duration ~/ 60} Hour${availableSpacesParams.duration ~/ 60 > 1 ? 's' : ''}';
 
-    return SingleChildScrollView( // Añade SingleChildScrollView
-        child: Padding(
+    return SingleChildScrollView(
+      // Añade SingleChildScrollView
+      child: Padding(
         padding: const EdgeInsets.all(8),
-    child: Column(
-    children: <Widget>[
-          Row(  // TODO add a toggle to switch between one-time and recurrent events
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: <Widget>[
-              Container(
-                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                decoration: BoxDecoration(
-                  color: const Color(0xFFFFFFFF),
-                  borderRadius: BorderRadius.circular(16),
-                  border: Border.all(color: const Color(0xFFD0D5DD), width: 1),
-                ),
-                child: const Text(
-                  'One-Time',
-                  style: TextStyle(
-                    fontFamily: 'Poppins',
-                    fontSize: 14,
-                    color: Color(0xFF475569),
-                  ),
-                ),
-              ),
-              const SizedBox(width: 12),
-              Container(
-                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                decoration: BoxDecoration(
-                  color: const Color(0xFF9DCC18),
-                  borderRadius: BorderRadius.circular(16),
-                  border: Border.all(color: const Color(0xFF9DCC18), width: 1),
-                ),
-                child: const Text(
-                  'Recurrent',
-                  style: TextStyle(
-                    fontFamily: 'Poppins',
-                    fontSize: 14,
-                    color: Color(0xFFFFFFFF),
-                  ),
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 20),
-          Container(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            decoration: BoxDecoration(
-              color: const Color(0xFFFFFFFF),
-              borderRadius: BorderRadius.circular(16),
-              border: Border.all(color: const Color(0xFFD0D5DD), width: 1),
-            ),
-            child: Column(
+        child: Column(
+          children: <Widget>[
+            Row(
+              // TODO add a toggle to switch between one-time and recurrent events
+              mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
                 Container(
-                  height: 56,
-                  child: Row(
-                    children: <Widget>[
-                      const Expanded(
-                        child: TextField(
-                          style: TextStyle(
-                            fontFamily: 'Poppins',
-                            fontSize: 16,
-                            color: Color(0xFF475569),
-                          ),
-                          decoration: InputDecoration(
-                            border: InputBorder.none,
-                            hintText: 'Event Name',
-                            hintStyle: TextStyle(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                  decoration: BoxDecoration(
+                    color: const Color(0xFFFFFFFF),
+                    borderRadius: BorderRadius.circular(16),
+                    border:
+                        Border.all(color: const Color(0xFFD0D5DD), width: 1),
+                  ),
+                  child: const Text(
+                    'One-Time',
+                    style: TextStyle(
+                      fontFamily: 'Poppins',
+                      fontSize: 14,
+                      color: Color(0xFF475569),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                  decoration: BoxDecoration(
+                    color: const Color(0xFF9DCC18),
+                    borderRadius: BorderRadius.circular(16),
+                    border:
+                        Border.all(color: const Color(0xFF9DCC18), width: 1),
+                  ),
+                  child: const Text(
+                    'Recurrent',
+                    style: TextStyle(
+                      fontFamily: 'Poppins',
+                      fontSize: 14,
+                      color: Color(0xFFFFFFFF),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 20),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              decoration: BoxDecoration(
+                color: const Color(0xFFFFFFFF),
+                borderRadius: BorderRadius.circular(16),
+                border: Border.all(color: const Color(0xFFD0D5DD), width: 1),
+              ),
+              child: Column(
+                children: <Widget>[
+                  Container(
+                    height: 56,
+                    child: Row(
+                      children: <Widget>[
+                        const Expanded(
+                          child: TextField(
+                            style: TextStyle(
                               fontFamily: 'Poppins',
                               fontSize: 16,
                               color: Color(0xFF475569),
                             ),
-                          ),
-                        ),
-                      ),
-                      SizedBox(
-                        width: 30,
-                        child: SvgPicture.asset('assets/icons/signature.svg',
-                            width: 24, height: 24, color: const Color(0xFF475569)),
-                      )
-                    ],
-                  ),
-                ),
-                Container(
-                  decoration: BoxDecoration(
-                    border: Border.all(
-                      color: const Color(0xFFD0D5DD),
-                      width: 1,
-                    ),
-                  ),
-                  height: 1,
-                ),
-                Container(
-                  height: 56,
-                  child: Row(
-                    children: <Widget>[
-                      Expanded(
-                        child: MultiSelectDropDown(
-                          controller: assistantsMultiSelectController,
-                          onOptionSelected: (List<ValueItem> selectedOptions) {},
-                          options: assistants.map((key) => ValueItem(label: key, value: key)).toList(),
-                          selectionType: SelectionType.multi,
-                          chipConfig: const ChipConfig(
-                            wrapType: WrapType.scroll,
-                            labelStyle: TextStyle(
-                              fontFamily: 'Poppins',
-                              fontSize: 16,
-                              color: Color(0xFFFFFFFF),
-                            ),
-                          ),
-                          optionTextStyle: const TextStyle(
-                            fontFamily: 'Poppins',
-                            fontSize: 16,
-                            color: Color(0xFF475569),
-                          ),
-                          borderColor: Colors.transparent,
-                          focusedBorderColor: Colors.transparent,
-                          borderWidth: 0,
-                          focusedBorderWidth: 0,
-                          clearIcon: const Icon(Icons.clear),
-                          padding: const EdgeInsets.all(0),
-                          hint: 'Assistants',
-                          hintStyle: const TextStyle(
-                            fontFamily: 'Poppins',
-                            fontSize: 16,
-                            color: Color(0xFF475569),
-                          ),
-                          hintPadding: const EdgeInsets.all(0),
-                        ),
-                      ),
-                      SizedBox(
-                          width: 30,
-                          child: SvgPicture.asset('assets/icons/person-chalkboard.svg',
-                              width: 24, height: 24, color: const Color(0xFF475569)),
-                      )
-                    ],
-                  ),
-                ),
-                Container(
-                  decoration: BoxDecoration(
-                    border: Border.all(
-                      color: const Color(0xFFD0D5DD),
-                      width: 1,
-                    ),
-                  ),
-                  height: 1,
-                ),
-                Container(
-                  height: 56,
-                  child: Row(
-                    children: <Widget>[
-                      Expanded(
-                        child: DropdownButtonFormField<String>(
-                          decoration: const InputDecoration(
-                            border: InputBorder.none,
-                            hintText: 'Reminder',
-                            hintStyle: TextStyle(
-                              fontFamily: 'Poppins',
-                              fontSize: 16,
-                              color: Color(0xFF475569),
-                            ),
-                          ),
-                          items: reminders.map((String value) {
-                            return DropdownMenuItem<String>(
-                              value: value,
-                              child: Text(
-                                value,
-                                style: const TextStyle(
-                                  fontFamily: 'Poppins',
-                                  fontSize: 16,
-                                  color: Color(0xFF475569),
-                                ),
+                            decoration: InputDecoration(
+                              border: InputBorder.none,
+                              hintText: 'Event Name',
+                              hintStyle: TextStyle(
+                                fontFamily: 'Poppins',
+                                fontSize: 16,
+                                color: Color(0xFF475569),
                               ),
-                            );
-                          }).toList(),
-                          onChanged: (String? newValue) {
-                            setState(() {
-                              _selectedReminder = newValue;
-                            });
-                          },
-                          value: _selectedReminder,
+                            ),
+                          ),
                         ),
-                      ),
-                      SizedBox(
+                        SizedBox(
                           width: 30,
-                          child: SvgPicture.asset('assets/icons/stopwatch.svg',
-                              width: 24, height: 24, color: const Color(0xFF475569)),
-                      ),
-                    ],
-                  ),
-                ),
-                Container(
-                  decoration: BoxDecoration(
-                    border: Border.all(
-                      color: const Color(0xFFD0D5DD),
-                      width: 1,
+                          child: SvgPicture.asset('assets/icons/signature.svg',
+                              width: 24,
+                              height: 24,
+                              color: const Color(0xFF475569)),
+                        )
+                      ],
                     ),
                   ),
-                  height: 1,
-                ),
-                Container(
-                  height: 56,
-                  child: Row(
-                    children: <Widget>[
-                      Expanded(
-                        child: MultiSelectDropDown(
-                          controller: labelsMultiSelectController,
-                          onOptionSelected: (List<ValueItem> selectedOptions) {},
-                          options: labels.map((key) => ValueItem(label: key, value: key)).toList(),
-                          selectionType: SelectionType.multi,
-                          chipConfig: const ChipConfig(
+                  Container(
+                    decoration: BoxDecoration(
+                      border: Border.all(
+                        color: const Color(0xFFD0D5DD),
+                        width: 1,
+                      ),
+                    ),
+                    height: 1,
+                  ),
+                  Container(
+                    height: 56,
+                    child: Row(
+                      children: <Widget>[
+                        Expanded(
+                          child: MultiSelectDropDown(
+                            controller: assistantsMultiSelectController,
+                            onOptionSelected:
+                                (List<ValueItem> selectedOptions) {},
+                            options: assistants
+                                .map((key) => ValueItem(label: key, value: key))
+                                .toList(),
+                            selectionType: SelectionType.multi,
+                            chipConfig: const ChipConfig(
                               wrapType: WrapType.scroll,
                               labelStyle: TextStyle(
                                 fontFamily: 'Poppins',
                                 fontSize: 16,
                                 color: Color(0xFFFFFFFF),
                               ),
+                            ),
+                            optionTextStyle: const TextStyle(
+                              fontFamily: 'Poppins',
+                              fontSize: 16,
+                              color: Color(0xFF475569),
+                            ),
+                            borderColor: Colors.transparent,
+                            focusedBorderColor: Colors.transparent,
+                            borderWidth: 0,
+                            focusedBorderWidth: 0,
+                            clearIcon: const Icon(Icons.clear),
+                            padding: const EdgeInsets.all(0),
+                            hint: 'Assistants',
+                            hintStyle: const TextStyle(
+                              fontFamily: 'Poppins',
+                              fontSize: 16,
+                              color: Color(0xFF475569),
+                            ),
+                            hintPadding: const EdgeInsets.all(0),
                           ),
-                          optionTextStyle: const TextStyle(
-                            fontFamily: 'Poppins',
-                            fontSize: 16,
-                            color: Color(0xFF475569),
-                          ),
-                          borderColor: Colors.transparent,
-                          focusedBorderColor: Colors.transparent,
-                          borderWidth: 0,
-                          focusedBorderWidth: 0,
-                          clearIcon: const Icon(Icons.clear),
-                          padding: const EdgeInsets.all(0),
-                          hint: 'Labels',
-                          hintStyle: const TextStyle(
-                            fontFamily: 'Poppins',
-                            fontSize: 16,
-                            color: Color(0xFF475569),
-                          ),
-                          hintPadding: const EdgeInsets.all(0),
                         ),
+                        SizedBox(
+                          width: 30,
+                          child: SvgPicture.asset(
+                              'assets/icons/person-chalkboard.svg',
+                              width: 24,
+                              height: 24,
+                              color: const Color(0xFF475569)),
+                        )
+                      ],
+                    ),
+                  ),
+                  Container(
+                    decoration: BoxDecoration(
+                      border: Border.all(
+                        color: const Color(0xFFD0D5DD),
+                        width: 1,
                       ),
-                      SizedBox(
-                        width: 30,
-                        child: SvgPicture.asset('assets/icons/tag.svg',
-                            width: 24, height: 24, color: const Color(0xFF475569)),
-                      )
-                    ],
+                    ),
+                    height: 1,
                   ),
-                ),
-              ],
-            ),
-          ),
-          const SizedBox(height: 20),
-          Container(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
-            decoration: BoxDecoration(
-              color: const Color(0xFFFFFFFF),
-              borderRadius: BorderRadius.circular(16),
-              border: Border.all(color: const Color(0xFFD0D5DD), width: 1),
-            ),
-            width: double.infinity,
-            child: const Row(
-              mainAxisAlignment: MainAxisAlignment.start,
-              children: <Widget>[
-                Expanded(
-                  child: Text(
-                      "Event Color",
-                      style: TextStyle(
-                          fontFamily: 'Poppins',
-                          fontSize: 16,
-                          color: Color(0xFF475569)
-                      )
+                  Container(
+                    height: 56,
+                    child: Row(
+                      children: <Widget>[
+                        Expanded(
+                          child: DropdownButtonFormField<String>(
+                            decoration: const InputDecoration(
+                              border: InputBorder.none,
+                              hintText: 'Reminder',
+                              hintStyle: TextStyle(
+                                fontFamily: 'Poppins',
+                                fontSize: 16,
+                                color: Color(0xFF475569),
+                              ),
+                            ),
+                            items: reminders.map((String value) {
+                              return DropdownMenuItem<String>(
+                                value: value,
+                                child: Text(
+                                  value,
+                                  style: const TextStyle(
+                                    fontFamily: 'Poppins',
+                                    fontSize: 16,
+                                    color: Color(0xFF475569),
+                                  ),
+                                ),
+                              );
+                            }).toList(),
+                            onChanged: (String? newValue) {
+                              setState(() {
+                                _selectedReminder = newValue;
+                              });
+                            },
+                            value: _selectedReminder,
+                          ),
+                        ),
+                        SizedBox(
+                          width: 30,
+                          child: SvgPicture.asset('assets/icons/stopwatch.svg',
+                              width: 24,
+                              height: 24,
+                              color: const Color(0xFF475569)),
+                        ),
+                      ],
+                    ),
                   ),
-                ),
-                EventColorInput(),
-              ]
+                  Container(
+                    decoration: BoxDecoration(
+                      border: Border.all(
+                        color: const Color(0xFFD0D5DD),
+                        width: 1,
+                      ),
+                    ),
+                    height: 1,
+                  ),
+                  Container(
+                    height: 56,
+                    child: Row(
+                      children: <Widget>[
+                        Expanded(
+                          child: MultiSelectDropDown(
+                            controller: labelsMultiSelectController,
+                            onOptionSelected:
+                                (List<ValueItem> selectedOptions) {},
+                            options: labels
+                                .map((key) => ValueItem(label: key, value: key))
+                                .toList(),
+                            selectionType: SelectionType.multi,
+                            chipConfig: const ChipConfig(
+                              wrapType: WrapType.scroll,
+                              labelStyle: TextStyle(
+                                fontFamily: 'Poppins',
+                                fontSize: 16,
+                                color: Color(0xFFFFFFFF),
+                              ),
+                            ),
+                            optionTextStyle: const TextStyle(
+                              fontFamily: 'Poppins',
+                              fontSize: 16,
+                              color: Color(0xFF475569),
+                            ),
+                            borderColor: Colors.transparent,
+                            focusedBorderColor: Colors.transparent,
+                            borderWidth: 0,
+                            focusedBorderWidth: 0,
+                            clearIcon: const Icon(Icons.clear),
+                            padding: const EdgeInsets.all(0),
+                            hint: 'Labels',
+                            hintStyle: const TextStyle(
+                              fontFamily: 'Poppins',
+                              fontSize: 16,
+                              color: Color(0xFF475569),
+                            ),
+                            hintPadding: const EdgeInsets.all(0),
+                          ),
+                        ),
+                        SizedBox(
+                          width: 30,
+                          child: SvgPicture.asset('assets/icons/tag.svg',
+                              width: 24,
+                              height: 24,
+                              color: const Color(0xFF475569)),
+                        )
+                      ],
+                    ),
+                  ),
+                ],
+              ),
             ),
-          ),
-          const SizedBox(height: 20),
-          InkWell(
-            onTap: () {
-              DatePicker.showDateTimePicker(
-                context,
-                showTitleActions: true,
-                minTime: DateTime.now(),
-                onConfirm: (date) {
-                  setState(() {
-                    _eventStartTime = date;
-                    ref.read(availableSpacesParamsProvider.notifier).state = AvailableSpacesParamsModel(
-                        DateFormat('EEEE').format(date),
-                        TimeOfDay(hour: date.hour, minute: date.minute),
-                        availableSpacesParams.duration
-                    );
-                  });
-                },
-                currentTime: _eventStartTime,
-              );
-            },
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 24), // Ajustado para aumentar la altura
+            const SizedBox(height: 20),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
               decoration: BoxDecoration(
                 color: const Color(0xFFFFFFFF),
                 borderRadius: BorderRadius.circular(16),
                 border: Border.all(color: const Color(0xFFD0D5DD), width: 1),
               ),
               width: double.infinity,
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.start,
-                children: <Widget>[ // Aumentado para mover el icono a la derecha
-                  SvgPicture.asset('assets/icons/hourglass-start.svg',
-                      width: 24, height: 24, color: const Color(0xFF475569)),
-                  const SizedBox(width: 12), // Espacio entre el icono y el texto
-                  Text(
-                    DateFormat('MMMM dd - HH:mm').format(_eventStartTime),
-                    style: const TextStyle(
-                        fontFamily: 'Poppins',
-                        fontSize: 16,
-                        color: Color(0xFF475569)),
-                  ),
-                ],
-              ),
-            ),
-          ),
-          const SizedBox(height: 12),
-          Row(
-            children: <Widget>[
-              Expanded(
-                flex: 1,
-                child: Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 24), // Ajustado para aumentar la altura
-                  decoration: BoxDecoration(
-                    color: const Color(0xFFFFFFFF),
-                    borderRadius: BorderRadius.circular(16),
-                    border: Border.all(color: const Color(0xFFD0D5DD), width: 1),
-                  ),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.start,
-                    children: <Widget>[
-                      SvgPicture.asset('assets/icons/calendar-day.svg',
-                          width: 24, height: 24, color: const Color(0xFF475569)),
-                      const SizedBox(width: 12), // Espaciado entre el icono y el texto
-                      Text(
-                        DateFormat('EEEE').format(_eventStartTime), // Muestra el día de la semana
-                        style: const TextStyle(
-                            fontFamily: 'Poppins',
-                            fontSize: 16,
-                            color: Color(0xFF475569)),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-              const SizedBox(width: 8),
-              Expanded(
-                flex: 1,
-                child: Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12), // Ajustado para aumentar la altura
-                  decoration: BoxDecoration(
-                    color: const Color(0xFFFFFFFF),
-                    borderRadius: BorderRadius.circular(16),
-                    border: Border.all(color: const Color(0xFFD0D5DD), width: 1),
-                  ),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.start,
-                    children: [
-                      SvgPicture.asset('assets/icons/clock.svg',
-                          width: 24, height: 24, color: const Color(0xFF475569)),
-                      const SizedBox(width: 12),
-                      Expanded(
-                        child: DropdownButtonHideUnderline(
-                          child: DropdownButton<String>(
-                            value: _selectedDuration, // Usa la variable de estado para el valor actual
-                            items: <String>['1 Hour', '2 Hours', '3 Hours', '4 Hours'].map((String value) {
-                              return DropdownMenuItem<String>(
-                                value: value,
-                                child: Text(value),
-                              );
-                            }).toList(),
-                            onChanged: (newValue) {
-                              setState(() {
-                                _selectedDuration = newValue!; // Actualiza la variable de estado con la nueva selección
-                                ref.read(availableSpacesParamsProvider.notifier).state = AvailableSpacesParamsModel(
-                                    availableSpacesParams.dayOfWeek,
-                                    availableSpacesParams.startTime,
-                                    int.parse(newValue.substring(0, 1)) * 60 // FIXME - This is highly coupled with the format of the string
-                                );
-                              });
-                            },
-                            style: const TextStyle(
+              child: const Row(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  children: <Widget>[
+                    Expanded(
+                      child: Text("Event Color",
+                          style: TextStyle(
                               fontFamily: 'Poppins',
                               fontSize: 16,
-                              color: Color(0xFF475569),
+                              color: Color(0xFF475569))),
+                    ),
+                    EventColorInput(),
+                  ]),
+            ),
+            const SizedBox(height: 20),
+            InkWell(
+              onTap: () {
+                DatePicker.showDateTimePicker(
+                  context,
+                  showTitleActions: true,
+                  minTime: DateTime.now(),
+                  onConfirm: (date) {
+                    setState(() {
+                      _eventStartTime = date;
+                      ref.read(availableSpacesParamsProvider.notifier).state =
+                          AvailableSpacesParamsModel(
+                              DateFormat('EEEE').format(date),
+                              TimeOfDay(hour: date.hour, minute: date.minute),
+                              availableSpacesParams.duration);
+                    });
+                  },
+                  currentTime: _eventStartTime,
+                );
+              },
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 24), // Ajustado para aumentar la altura
+                decoration: BoxDecoration(
+                  color: const Color(0xFFFFFFFF),
+                  borderRadius: BorderRadius.circular(16),
+                  border: Border.all(color: const Color(0xFFD0D5DD), width: 1),
+                ),
+                width: double.infinity,
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  children: <Widget>[
+                    // Aumentado para mover el icono a la derecha
+                    SvgPicture.asset('assets/icons/hourglass-start.svg',
+                        width: 24, height: 24, color: const Color(0xFF475569)),
+                    const SizedBox(
+                        width: 12), // Espacio entre el icono y el texto
+                    Text(
+                      DateFormat('MMMM dd - HH:mm').format(_eventStartTime),
+                      style: const TextStyle(
+                          fontFamily: 'Poppins',
+                          fontSize: 16,
+                          color: Color(0xFF475569)),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: <Widget>[
+                Expanded(
+                  flex: 1,
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 16,
+                        vertical: 24), // Ajustado para aumentar la altura
+                    decoration: BoxDecoration(
+                      color: const Color(0xFFFFFFFF),
+                      borderRadius: BorderRadius.circular(16),
+                      border:
+                          Border.all(color: const Color(0xFFD0D5DD), width: 1),
+                    ),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.start,
+                      children: <Widget>[
+                        SvgPicture.asset('assets/icons/calendar-day.svg',
+                            width: 24,
+                            height: 24,
+                            color: const Color(0xFF475569)),
+                        const SizedBox(
+                            width: 12), // Espaciado entre el icono y el texto
+                        Text(
+                          DateFormat('EEEE').format(
+                              _eventStartTime), // Muestra el día de la semana
+                          style: const TextStyle(
+                              fontFamily: 'Poppins',
+                              fontSize: 16,
+                              color: Color(0xFF475569)),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  flex: 1,
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 16,
+                        vertical: 12), // Ajustado para aumentar la altura
+                    decoration: BoxDecoration(
+                      color: const Color(0xFFFFFFFF),
+                      borderRadius: BorderRadius.circular(16),
+                      border:
+                          Border.all(color: const Color(0xFFD0D5DD), width: 1),
+                    ),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.start,
+                      children: [
+                        SvgPicture.asset('assets/icons/clock.svg',
+                            width: 24,
+                            height: 24,
+                            color: const Color(0xFF475569)),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: DropdownButtonHideUnderline(
+                            child: DropdownButton<String>(
+                              value:
+                                  _selectedDuration, // Usa la variable de estado para el valor actual
+                              items: <String>[
+                                '1 Hour',
+                                '2 Hours',
+                                '3 Hours',
+                                '4 Hours'
+                              ].map((String value) {
+                                return DropdownMenuItem<String>(
+                                  value: value,
+                                  child: Text(value),
+                                );
+                              }).toList(),
+                              onChanged: (newValue) {
+                                setState(() {
+                                  _selectedDuration =
+                                      newValue!; // Actualiza la variable de estado con la nueva selección
+                                  ref
+                                          .read(availableSpacesParamsProvider
+                                              .notifier)
+                                          .state =
+                                      AvailableSpacesParamsModel(
+                                          availableSpacesParams.dayOfWeek,
+                                          availableSpacesParams.startTime,
+                                          int.parse(newValue.substring(0, 1)) *
+                                              60 // FIXME - This is highly coupled with the format of the string
+                                          );
+                                });
+                              },
+                              style: const TextStyle(
+                                fontFamily: 'Poppins',
+                                fontSize: 16,
+                                color: Color(0xFF475569),
+                              ),
                             ),
                           ),
                         ),
-                      ),
-                    ],
+                      ],
+                    ),
                   ),
                 ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 12),
-          InkWell(
-            onTap: () {
-              showGeneralDialog(
-                context: context,
-                barrierDismissible: true,
-                barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
-                barrierColor: Colors.black45,
-                transitionDuration: const Duration(milliseconds: 200),
-                pageBuilder: (BuildContext buildContext, Animation animation, Animation secondaryAnimation) {
-                  return Center(
-                    child: BackdropFilter(
-                      filter: ImageFilter.blur(sigmaX: 5, sigmaY: 5),
-                      child: PlaceRecommendationsDialog(),
-                    ),
-                  );
-                },
-              );
-            },
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
-              decoration: BoxDecoration(
-                color: const Color(0xFF9DCC18).withOpacity(0.15),
-                borderRadius: BorderRadius.circular(16),
-                border: Border.all(color: const Color(0xFFD0D5DD), width: 1),
-              ),
-              width: double.infinity,
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: <Widget>[
-                  const Text(
-                      "Find a Place on Campus",
-                      style: TextStyle(
-                          fontFamily: 'Poppins',
-                          fontSize: 16,
-                          color: Color(0xFF475569),
-                          fontWeight: FontWeight.bold
-                      )
-                  ),
-                  const SizedBox(width: 12),
-                  SvgPicture.asset('assets/icons/location-dot.svg',
-                      width: 24, height: 24, color: const Color(0xFF475569)),
-                ]
+              ],
+            ),
+            const SizedBox(height: 12),
+            InkWell(
+              onTap: () {
+                showGeneralDialog(
+                  context: context,
+                  barrierDismissible: true,
+                  barrierLabel: MaterialLocalizations.of(context)
+                      .modalBarrierDismissLabel,
+                  barrierColor: Colors.black45,
+                  transitionDuration: const Duration(milliseconds: 200),
+                  pageBuilder: (BuildContext buildContext, Animation animation,
+                      Animation secondaryAnimation) {
+                    return Center(
+                      child: BackdropFilter(
+                        filter: ImageFilter.blur(sigmaX: 5, sigmaY: 5),
+                        child: PlaceRecommendationsDialog(),
+                      ),
+                    );
+                  },
+                );
+              },
+              child: Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
+                decoration: BoxDecoration(
+                  color: const Color(0xFF9DCC18).withOpacity(0.15),
+                  borderRadius: BorderRadius.circular(16),
+                  border: Border.all(color: const Color(0xFFD0D5DD), width: 1),
+                ),
+                width: double.infinity,
+                child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: <Widget>[
+                      const Text("Find a Place on Campus",
+                          style: TextStyle(
+                              fontFamily: 'Poppins',
+                              fontSize: 16,
+                              color: Color(0xFF475569),
+                              fontWeight: FontWeight.bold)),
+                      const SizedBox(width: 12),
+                      SvgPicture.asset('assets/icons/location-dot.svg',
+                          width: 24,
+                          height: 24,
+                          color: const Color(0xFF475569)),
+                    ]),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
-    ),
     );
   }
 }
@@ -588,12 +664,12 @@ class _CreateClassPageState extends ConsumerState<CreateClassPage> {
 class PlaceRecommendationsDialog extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-
-    var availableSpaces = ref.watch(availableSpacesProvider).value ?? <AvailableSpacesResponseModel>[];
+    var availableSpaces = ref.watch(availableSpacesProvider).value ??
+        <AvailableSpacesResponseModel>[];
 
     return ConstrainedBox(
       constraints: BoxConstraints(
-          maxHeight: MediaQuery.of(context).size.height * 0.6,
+        maxHeight: MediaQuery.of(context).size.height * 0.6,
       ),
       child: Container(
         width: MediaQuery.of(context).size.width - 24,
@@ -605,67 +681,67 @@ class PlaceRecommendationsDialog extends ConsumerWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: <Widget>[
-            const Text(
-                'Place Recommendations',
+            const Text('Place Recommendations',
                 style: TextStyle(
                   fontFamily: 'Poppins',
                   fontSize: 24,
                   fontWeight: FontWeight.bold,
                   color: Color(0xFF000000),
                   decoration: TextDecoration.none,
-                )
-            ),
+                )),
             Expanded(
               child: ListView.separated(
-                  padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 8),
+                  padding:
+                      const EdgeInsets.symmetric(vertical: 8, horizontal: 8),
                   itemBuilder: (BuildContext context, int index) => Container(
-                    padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 20),
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: <Widget>[
-                        Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 8, vertical: 20),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
                           children: <Widget>[
-                            Text(
-                                '${availableSpaces[index].building}-${availableSpaces[index].room}',
-                                style: const TextStyle(
-                                  fontFamily: 'Poppins',
-                                  fontSize: 20,
-                                  color: Color(0xFF475569),
-                                  decoration: TextDecoration.none,
-                                  fontWeight: FontWeight.bold,
-                                )
+                            Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: <Widget>[
+                                Text(
+                                    '${availableSpaces[index].building}-${availableSpaces[index].room}',
+                                    style: const TextStyle(
+                                      fontFamily: 'Poppins',
+                                      fontSize: 20,
+                                      color: Color(0xFF475569),
+                                      decoration: TextDecoration.none,
+                                      fontWeight: FontWeight.bold,
+                                    )),
+                                const SizedBox(height: 4),
+                                Text(
+                                    'Available from ${availableSpaces[index].availableFrom.substring(0, 2)}:${availableSpaces[index].availableFrom.substring(2)} to ${availableSpaces[index].availableUntil.substring(0, 2)}:${availableSpaces[index].availableUntil.substring(2)}',
+                                    style: const TextStyle(
+                                      fontFamily: 'Poppins',
+                                      fontSize: 12,
+                                      color: Color(0xFF475569),
+                                      decoration: TextDecoration.none,
+                                      fontWeight: FontWeight.normal,
+                                    )),
+                              ],
                             ),
-                            const SizedBox(height: 4),
-                            Text(
-                                'Available from ${availableSpaces[index].availableFrom.substring(0, 2)}:${availableSpaces[index].availableFrom.substring(2)} to ${availableSpaces[index].availableUntil.substring(0, 2)}:${availableSpaces[index].availableUntil.substring(2)}',
-                                style: const TextStyle(
-                                  fontFamily: 'Poppins',
-                                  fontSize: 12,
-                                  color: Color(0xFF475569),
-                                  decoration: TextDecoration.none,
-                                  fontWeight: FontWeight.normal,
-                                )
-                            ),
+                            Container(
+                              width: 80,
+                              height: 60,
+                              decoration: BoxDecoration(
+                                borderRadius: BorderRadius.circular(
+                                    8), // Borde redondeado
+                                image: DecorationImage(
+                                  image: AssetImage(
+                                      'assets/images/buildings/${availableSpaces[index].building}.jpg'),
+                                  fit: BoxFit.cover,
+                                ),
+                              ),
+                            )
                           ],
                         ),
-                        Container(
-                          width: 80,
-                          height: 60,
-                          decoration: BoxDecoration(
-                            borderRadius: BorderRadius.circular(8), // Borde redondeado
-                            image: DecorationImage(
-                              image: AssetImage('assets/images/buildings/${availableSpaces[index].building}.jpg'),
-                              fit: BoxFit.cover,
-                            ),
-                          ),
-                        )
-                      ],
-                    ),
-                  ),
-                  separatorBuilder: (BuildContext context, int index) => const Divider(height: 1, color: Color(0xFFD0D5DD)),
-                  itemCount: availableSpaces.length
-              ),
+                      ),
+                  separatorBuilder: (BuildContext context, int index) =>
+                      const Divider(height: 1, color: Color(0xFFD0D5DD)),
+                  itemCount: availableSpaces.length),
             ),
             Row(
               mainAxisAlignment: MainAxisAlignment.center,
@@ -674,155 +750,170 @@ class PlaceRecommendationsDialog extends ConsumerWidget {
                   onPressed: () {
                     Navigator.of(context).pop();
                   },
-                  child: const Text(
-                      'Cancel',
+                  child: const Text('Cancel',
                       style: TextStyle(
                         fontFamily: 'Poppins',
                         fontSize: 20,
                         color: Color(0xFF9FA5C0),
                         decoration: TextDecoration.none,
-                      )
-                  ),
+                      )),
                 ),
                 const SizedBox(width: 48),
                 TextButton(
                   onPressed: () {
-                    Navigator.of(context).pop(); // Cierra el diálogo de recomendaciones de lugares actual
+                    Navigator.of(context)
+                        .pop(); // Cierra el diálogo de recomendaciones de lugares actual
 
                     // Muestra el nuevo ModalBottomSheet desde abajo
                     showModalBottomSheet(
                       context: context,
-                        builder: (BuildContext context) {
-                          return BackdropFilter(
-                            filter: ImageFilter.blur(sigmaX: 5, sigmaY: 5),
-                            child: Container(
-                              height: MediaQuery.of(context).size.height * 0.3, // Cambiar el valor para ajustar el tamaño del modal
-                              decoration: BoxDecoration(
-                                color: Colors.white,
-                                borderRadius: BorderRadius.only(
-                                  topLeft: Radius.circular(20),
-                                  topRight: Radius.circular(20),
-                                ),
-                              ),
-                              child: Column(
-                                children: [
-                                  Padding(
-                                    padding: const EdgeInsets.all(16.0),
-                                    child: Text(
-                                      'Rate your recommendations', // Agregar el texto deseado
-                                      style: TextStyle(
-                                        fontFamily: 'Poppins',
-                                        fontSize: 28,
-                                        color: Colors.black,
-                                        decoration: TextDecoration.none,
-                                      ),
-                                    ),
-                                  ),
-                                  Expanded(
-                                    child: Center(
-                                      child: Container(
-                                        width: MediaQuery.of(context).size.width * 1, // Cambiar el valor para ajustar el ancho del Rating Bar
-                                        child: Column(
-                                          mainAxisAlignment: MainAxisAlignment.center,
-                                          children: [
-                                            RatingBar.builder(
-                                              initialRating: 5,
-                                              minRating: 1,
-                                              direction: Axis.horizontal,
-                                              allowHalfRating: true,
-                                              itemPadding: EdgeInsets.symmetric(horizontal: 6.0),
-                                              itemBuilder: (context, index) {
-                                                switch(index){
-                                                  case 0:
-                                                    return Icon(
-                                                      Icons.sentiment_very_dissatisfied,
-                                                      color: Colors.red,
-                                                    );
-                                                  case 1:
-                                                    return Icon(
-                                                      Icons.sentiment_dissatisfied,
-                                                      color: Colors.redAccent,
-                                                    );
-                                                  case 2:
-                                                    return Icon(
-                                                      Icons.sentiment_neutral,
-                                                      color: Colors.amber,
-                                                    );
-                                                  case 3:
-                                                    return Icon(
-                                                      Icons.sentiment_satisfied,
-                                                      color: Colors.lightGreen,
-                                                    );
-                                                  case 4:
-                                                    return Icon(
-                                                      Icons.sentiment_very_satisfied,
-                                                      color: Colors.green,
-                                                    );
-                                                  default:
-                                                    return Container();
-                                                }
-                                              },
-                                              onRatingUpdate: (rating) {
-                                                print(rating);
-                                              },
-                                            ),
-                                          ],
-                                        ),
-                                      ),
-                                    ),
-                                  ),
-                                  SizedBox(height: 0), // Espacio entre el Rating Bar y los botones
-                                  Row(
-                                    mainAxisAlignment: MainAxisAlignment.center,
-                                    children: [
-                                      TextButton(
-                                        onPressed: () {
-                                          Navigator.of(context).pop();
-                                        },
-                                        child: Text(
-                                          'Cancel', // Agregar el texto deseado
-                                          style: TextStyle(
-                                            fontFamily: 'Poppins',
-                                            fontSize: 20,
-                                            color: Colors.red, // Cambiar el color deseado
-                                            decoration: TextDecoration.none,
-                                          ),
-                                        ),
-                                      ),
-                                      SizedBox(width: 32), // Espacio entre los botones
-                                      ElevatedButton(
-                                        onPressed: () {
-                                          // Lógica para el botón "Submit"
-                                          Navigator.of(context).pop();
-                                        },
-                                        style: ButtonStyle(
-                                          backgroundColor: MaterialStateProperty.all(Colors.green), // Cambiar el color deseado
-                                          shape: MaterialStateProperty.all(
-                                            RoundedRectangleBorder(
-                                              borderRadius: BorderRadius.circular(8),
-                                            ),
-                                          ),
-                                        ),
-                                        child: Text(
-                                          'Submit', // Agregar el texto deseado
-                                          style: TextStyle(
-                                            fontFamily: 'Poppins',
-                                            fontSize: 20,
-                                            color: Colors.white,
-                                            decoration: TextDecoration.none,
-                                          ),
-                                        ),
-                                      ),
-                                    ],
-                                  ),
-                                ],
+                      builder: (BuildContext context) {
+                        return BackdropFilter(
+                          filter: ImageFilter.blur(sigmaX: 5, sigmaY: 5),
+                          child: Container(
+                            height: MediaQuery.of(context).size.height *
+                                0.3, // Cambiar el valor para ajustar el tamaño del modal
+                            decoration: BoxDecoration(
+                              color: Colors.white,
+                              borderRadius: BorderRadius.only(
+                                topLeft: Radius.circular(20),
+                                topRight: Radius.circular(20),
                               ),
                             ),
-                          );
-                        },
-                        isScrollControlled: true, // Permite que el sheet ocupe más espacio
-                        backgroundColor: Colors.transparent, // Hace el fondo transparente para permitir el efecto blur
-                      );
+                            child: Column(
+                              children: [
+                                Padding(
+                                  padding: const EdgeInsets.all(16.0),
+                                  child: Text(
+                                    'Rate your recommendations', // Agregar el texto deseado
+                                    style: TextStyle(
+                                      fontFamily: 'Poppins',
+                                      fontSize: 28,
+                                      color: Colors.black,
+                                      decoration: TextDecoration.none,
+                                    ),
+                                  ),
+                                ),
+                                Expanded(
+                                  child: Center(
+                                    child: Container(
+                                      width: MediaQuery.of(context).size.width *
+                                          1, // Cambiar el valor para ajustar el ancho del Rating Bar
+                                      child: Column(
+                                        mainAxisAlignment:
+                                            MainAxisAlignment.center,
+                                        children: [
+                                          RatingBar.builder(
+                                            initialRating: 5,
+                                            minRating: 1,
+                                            direction: Axis.horizontal,
+                                            allowHalfRating: true,
+                                            itemPadding: EdgeInsets.symmetric(
+                                                horizontal: 6.0),
+                                            itemBuilder: (context, index) {
+                                              switch (index) {
+                                                case 0:
+                                                  return Icon(
+                                                    Icons
+                                                        .sentiment_very_dissatisfied,
+                                                    color: Colors.red,
+                                                  );
+                                                case 1:
+                                                  return Icon(
+                                                    Icons
+                                                        .sentiment_dissatisfied,
+                                                    color: Colors.redAccent,
+                                                  );
+                                                case 2:
+                                                  return Icon(
+                                                    Icons.sentiment_neutral,
+                                                    color: Colors.amber,
+                                                  );
+                                                case 3:
+                                                  return Icon(
+                                                    Icons.sentiment_satisfied,
+                                                    color: Colors.lightGreen,
+                                                  );
+                                                case 4:
+                                                  return Icon(
+                                                    Icons
+                                                        .sentiment_very_satisfied,
+                                                    color: Colors.green,
+                                                  );
+                                                default:
+                                                  return Container();
+                                              }
+                                            },
+                                            onRatingUpdate: (rating) {
+                                              print(rating);
+                                            },
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                                SizedBox(
+                                    height:
+                                        0), // Espacio entre el Rating Bar y los botones
+                                Row(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    TextButton(
+                                      onPressed: () {
+                                        Navigator.of(context).pop();
+                                      },
+                                      child: Text(
+                                        'Cancel', // Agregar el texto deseado
+                                        style: TextStyle(
+                                          fontFamily: 'Poppins',
+                                          fontSize: 20,
+                                          color: Colors
+                                              .red, // Cambiar el color deseado
+                                          decoration: TextDecoration.none,
+                                        ),
+                                      ),
+                                    ),
+                                    SizedBox(
+                                        width: 32), // Espacio entre los botones
+                                    ElevatedButton(
+                                      onPressed: () {
+                                        // Lógica para el botón "Submit"
+                                        Navigator.of(context).pop();
+                                      },
+                                      style: ButtonStyle(
+                                        backgroundColor:
+                                            MaterialStateProperty.all(Colors
+                                                .green), // Cambiar el color deseado
+                                        shape: MaterialStateProperty.all(
+                                          RoundedRectangleBorder(
+                                            borderRadius:
+                                                BorderRadius.circular(8),
+                                          ),
+                                        ),
+                                      ),
+                                      child: Text(
+                                        'Submit', // Agregar el texto deseado
+                                        style: TextStyle(
+                                          fontFamily: 'Poppins',
+                                          fontSize: 20,
+                                          color: Colors.white,
+                                          decoration: TextDecoration.none,
+                                        ),
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ],
+                            ),
+                          ),
+                        );
+                      },
+                      isScrollControlled:
+                          true, // Permite que el sheet ocupe más espacio
+                      backgroundColor: Colors
+                          .transparent, // Hace el fondo transparente para permitir el efecto blur
+                    );
                   },
                   child: const Text(
                     'Confirm',
@@ -834,9 +925,6 @@ class PlaceRecommendationsDialog extends ConsumerWidget {
                     ),
                   ),
                 )
-
-
-
               ],
             )
           ],
@@ -846,7 +934,6 @@ class PlaceRecommendationsDialog extends ConsumerWidget {
   }
 }
 
-
 class EventColorInput extends StatefulWidget {
   const EventColorInput({Key? key}) : super(key: key);
 
@@ -855,7 +942,6 @@ class EventColorInput extends StatefulWidget {
 }
 
 class _EventColorInputState extends State<EventColorInput> {
-
   Color currentColor = Colors.deepPurpleAccent;
   void changeColor(Color color) {
     setState(() => currentColor = color);
@@ -880,7 +966,8 @@ class _EventColorInputState extends State<EventColorInput> {
                     displayThumbColor: true,
                     enableAlpha: false,
                     paletteType: PaletteType.hsv,
-                    pickerAreaBorderRadius: const BorderRadius.all(Radius.circular(16)),
+                    pickerAreaBorderRadius:
+                        const BorderRadius.all(Radius.circular(16)),
                   ),
                 ),
               );
@@ -898,8 +985,6 @@ class _EventColorInputState extends State<EventColorInput> {
         child: const SizedBox(
           width: 24,
           height: 24,
-        )
-    );
+        ));
   }
 }
-

--- a/unischedule/lib/providers/events_page/events_state_notifier.dart
+++ b/unischedule/lib/providers/events_page/events_state_notifier.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:unischedule/models/events_page/event_model.dart';
+
+class EventsStateNotifier extends StateNotifier<List<Event>> {
+  List<Event> allEvents = [];
+
+  EventsStateNotifier(List<Event> initialEvents) : super(initialEvents) {
+    allEvents = initialEvents;
+  }
+
+  void filterEvents(String searchText) {
+    if (searchText.isEmpty) {
+      state = allEvents;
+    } else {
+      state = allEvents.where((event) =>
+        event.name.toLowerCase().contains(searchText.toLowerCase())).toList();
+    }
+  }
+
+  void setEvents(List<Event> events) {
+    state = events;
+    allEvents = events;
+  }
+}
+
+final eventsStateNotifierProvider = StateNotifierProvider<EventsStateNotifier, List<Event>>((ref) {
+  return EventsStateNotifier([]);
+});

--- a/unischedule/lib/providers/events_page/events_state_notifier.dart
+++ b/unischedule/lib/providers/events_page/events_state_notifier.dart
@@ -21,6 +21,11 @@ class EventsStateNotifier extends StateNotifier<List<Event>> {
     state = events;
     allEvents = events;
   }
+
+  void addEvent(Event event) {
+    state = [...state, event];
+    allEvents = [...allEvents, event];
+  }
 }
 
 final eventsStateNotifierProvider = StateNotifierProvider<EventsStateNotifier, List<Event>>((ref) {


### PR DESCRIPTION
I created new providers to manage the state of events. I used those providers to create a very basic new event within the create-class page. I also updated the UI to allow the rendering of any event. This handles:

- Any day of the week (Mon-Sun)
- Any hour of the day (00:00 - 23:59)
- Scroll to see any element
- Event name is displayed dynamically (I calculate appropriate number of lines and use overflow with ellipsis)
- Data is fetched from the database

https://github.com/ISIS3510-202410-Team-13/Flutter/assets/68788933/08345b2b-740d-47c7-857e-af99244f2fe1

There are many things to consider in following implementations:
- How to handle stacking elements over the same hours
- Saving new events to the database
- **Differentiating recurrent vs one-time events** (this might involve changes in the database)
- Include duration, color, labels, title, etc when creating the event

I will take care of more of these things in the following weeks. For now, this version works good enough while I fix some issues related to technical debt which are a must at this point!

