### PR TITLE
Fix error when rendering profile icons in groups card when there are less than 3 members

### DIFF
--- a/unischedule/lib/views/groups/widgets/group_card.dart
+++ b/unischedule/lib/views/groups/widgets/group_card.dart
@@ -64,7 +64,6 @@ class GroupCard extends StatelessWidget {
             left: 10,
             top: 12,
             child: ProfileIconsRow(
-                memberCount: group.members.length,
                 imagePaths: group.profilePictures
             ),
           ),

--- a/unischedule/lib/views/groups/widgets/profile_icons_row.dart
+++ b/unischedule/lib/views/groups/widgets/profile_icons_row.dart
@@ -1,14 +1,17 @@
+import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:unischedule/constants/constants.dart';
 
 class ProfileIconsRow extends StatelessWidget {
-  final int memberCount;
   final List<String> imagePaths;
-  const ProfileIconsRow({super.key, required this.memberCount, required this.imagePaths});
+  const ProfileIconsRow({super.key, required this.imagePaths});
 
   @override
   Widget build(BuildContext context) {
+    final memberCount = imagePaths.length;
+    final remainingCountText = imagePaths.length > 3 ? '+${memberCount - 3}' : '';
+    print([memberCount, imagePaths]);
     return Container(
       width: 120,
       decoration: BoxDecoration(
@@ -17,53 +20,52 @@ class ProfileIconsRow extends StatelessWidget {
       ),
       child: Stack(
         alignment: Alignment.center,
-        children: <Widget>[
-          for (var i = 0; i < 3; i++)
+        children: [
+          for (int i = min(3,memberCount) - 1; i >= 0; i--)
             Positioned(
-              left: i==2 ? 0 : (2-i) * 20.0,
+              left: i * 20.0,
               child: CircleAvatar(
                 radius: 20,
                 backgroundColor: ColorConstants.limerick,
                 child: Container(
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      border: Border.all(
-                        color: ColorConstants.white,
-                        width: 1,
-                      ),
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    border: Border.all(
+                      color: ColorConstants.white,
+                      width: 1,
                     ),
-                    child: CachedNetworkImage(
-                      imageUrl: imagePaths[i],
-                      fadeInDuration: const Duration(milliseconds: 100),
-                      fadeOutDuration: const Duration(milliseconds: 100),
-                      filterQuality: FilterQuality.none,
-                      maxHeightDiskCache: 100,
-                      imageBuilder: (context, imageProvider) => CircleAvatar(
-                        radius: 20,
-                        backgroundImage: imageProvider,
-                      ),
-                      placeholder: (context, url) => const CircleAvatar(
-                        radius: 20,
-                        backgroundColor: ColorConstants.white,
-                      ),
-                      errorWidget: (context, url, error) => const CircleAvatar(
-                        radius: 20,
-                        backgroundColor: ColorConstants.white,
-                        child: Icon(Icons.error, color: ColorConstants.red),
-                      ),
-                    )
+                  ),
+                  child: CachedNetworkImage(
+                    imageUrl: imagePaths[i],
+                    fadeInDuration: const Duration(milliseconds: 100),
+                    fadeOutDuration: const Duration(milliseconds: 100),
+                    filterQuality: FilterQuality.none,
+                    maxHeightDiskCache: 100,
+                    imageBuilder: (context, imageProvider) => CircleAvatar(
+                      radius: 20,
+                      backgroundImage: imageProvider,
+                    ),
+                    placeholder: (context, url) => const CircleAvatar(
+                      radius: 20,
+                      backgroundColor: ColorConstants.white,
+                    ),
+                    errorWidget: (context, url, error) => const CircleAvatar(
+                      radius: 20,
+                      backgroundColor: ColorConstants.white,
+                      child: Icon(Icons.error, color: ColorConstants.red),
+                    ),
+                  )
                 ),
               ),
             ),
-          if (memberCount > 3)
-            Container(
-              padding: const EdgeInsets.fromLTRB(6, 8, 16, 8),
-              alignment: Alignment.centerRight,
-              child: Text(
-                '+${memberCount - 3}',
-                style: Theme.of(context).textTheme.headlineSmall,
-              ),
+          Container(
+            padding: const EdgeInsets.fromLTRB(6, 8, 16, 8),
+            alignment: Alignment.centerRight,
+            child: Text(
+              remainingCountText,
+              style: Theme.of(context).textTheme.headlineSmall,
             ),
+          ),
         ],
       ),
     );


### PR DESCRIPTION
When there are less than 3 members, the white background does not render properly, causing Stack to throw an exception for undefined size behavior. For this, I chose to leave the white background as-is, but only show the text of remainder members when there is at least one. This causes the row to have empty whitespace, as you can see in the image. We can address this better later. For now, it works with any number of members in the group.

I also changed the iterator to traverse the array up to the point where there are still values. Previously, it was fixed to at least 3, causing errors.

<img width="401" alt="image" src="https://github.com/ISIS3510-202410-Team-13/Flutter/assets/68788933/811edb64-f5bc-41d0-8901-bbd14d416f31">
