### PR TITLE
Add empty state handling for groups and events in HomeView

### DIFF
--- a/unischedule/lib/views/home/home_view.dart
+++ b/unischedule/lib/views/home/home_view.dart
@@ -66,16 +66,45 @@ class _HomeViewState extends ConsumerState<HomeView> {
                 ),
                 Expanded(
                   child: groupsProvider.when(
-                    data: (groups) => ListView.builder(
-                      scrollDirection: Axis.horizontal,
-                      itemCount: groups.length,
-                      itemBuilder: (context, index) {
-                        final GroupModel group = groups[index];
-                        return GroupCard(group: group);
-                      },
-                    ),
+                    data: (groups) {
+                      final bool allGroupsEmpty = groups.isEmpty;
+                      final connectivityStatus = ref.watch(connectivityStatusProvider);
+
+                      return connectivityStatus == ConnectivityStatus.isDisconnected && allGroupsEmpty
+                          ? Center(
+                        child: Text(
+                          "No groups to display at the moment. Please check your internet connection!",
+                          style: TextStyle(
+                              fontFamily: 'Poppins',
+                              fontWeight: FontWeight.w600,
+                              fontSize: 14,
+                              color: Colors.grey),
+                          textAlign: TextAlign.center,
+                        ),
+                      )
+                          : allGroupsEmpty
+                          ? Center(
+                        child: Text(
+                          "You currently have no groups to display. ",
+                          style: TextStyle(
+                              fontFamily: 'Poppins',
+                              fontWeight: FontWeight.w600,
+                              fontSize: 14,
+                              color: Colors.grey),
+                          textAlign: TextAlign.center,
+                        ),
+                      )
+                          : ListView.builder(
+                        scrollDirection: Axis.horizontal,
+                        itemCount: groups.length,
+                        itemBuilder: (context, index) {
+                          final GroupModel group = groups[index];
+                          return GroupCard(group: group);
+                        },
+                      );
+                    },
                     loading: () => const Center(child: CircularProgressIndicator()),
-                    error: (error, stack) => Padding( //TODO Change this to a custom error widget (toast)
+                    error: (error, stack) => Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 8.0),
                       child: Text(
                           error.toString(),
@@ -83,6 +112,7 @@ class _HomeViewState extends ConsumerState<HomeView> {
                       ),
                     ),
                   ),
+
                 ),
                 Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 8.0),
@@ -96,16 +126,45 @@ class _HomeViewState extends ConsumerState<HomeView> {
                 ),
                 Expanded(
                   child: eventsProvider.when(
-                    data: (events) => ListView.builder(
-                      scrollDirection: Axis.horizontal,
-                      itemCount: events.length,
-                      itemBuilder: (context, index) {
-                        final EventModel event = events[index];
-                        return EventCard(event: event);
-                      },
-                    ),
+                    data: (events) {
+                      final bool allEventsEmpty = events.isEmpty;
+                      final connectivityStatus = ref.watch(connectivityStatusProvider);
+
+                      return connectivityStatus == ConnectivityStatus.isDisconnected && allEventsEmpty
+                          ? Center(
+                        child: Text(
+                          "No events to display at the moment. Please check your internet connection!",
+                          style: TextStyle(
+                              fontFamily: 'Poppins',
+                              fontWeight: FontWeight.w600,
+                              fontSize: 14,
+                              color: Colors.grey),
+                          textAlign: TextAlign.center,
+                        ),
+                      )
+                          : allEventsEmpty
+                          ? Center(
+                        child: Text(
+                          "You currently have no events to display.",
+                          style: TextStyle(
+                              fontFamily: 'Poppins',
+                              fontWeight: FontWeight.w600,
+                              fontSize: 14,
+                              color: Colors.grey),
+                          textAlign: TextAlign.center,
+                        ),
+                      )
+                          : ListView.builder(
+                        scrollDirection: Axis.horizontal,
+                        itemCount: events.length,
+                        itemBuilder: (context, index) {
+                          final EventModel event = events[index];
+                          return EventCard(event: event);
+                        },
+                      );
+                    },
                     loading: () => const Center(child: CircularProgressIndicator()),
-                    error: (error, stack) => Padding( //TODO Change this to a custom error widget (toast)
+                    error: (error, stack) => Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 8.0),
                       child: Text(
                           error.toString(),
@@ -113,6 +172,7 @@ class _HomeViewState extends ConsumerState<HomeView> {
                       ),
                     ),
                   ),
+
                 ),
               ],
             ),


### PR DESCRIPTION
### Enhancements in HomeView
This pull request introduces enhancements to the `HomeView` by implementing user-friendly messages for different empty states of groups and events lists. These changes improve user experience by clearly communicating the state of content availability under various conditions such as no internet connectivity or simply no groups or events joined by the user.

#### Key Changes:
1. **Empty State Handling**: Added checks for empty lists of groups and events. Depending on the internet connectivity and the actual content availability, different messages are displayed to the user.
   - If there's no internet connection and the lists are empty, the user is informed to check their connection.
   - If the lists are empty due to not being part of any groups or events, appropriate messages guide users to join or add new items.

2. **Connectivity Checks**: Integrated connectivity status checks using `connectivityStatusProvider` to distinguish between no internet connection and empty content states.

These changes ensure that users have a clear understanding of why no groups or events are displayed and encourage interaction by joining groups or adding events as necessary.

#### Video:


https://github.com/ISIS3510-202410-Team-13/Flutter/assets/78111224/76264fb9-28ed-4799-bf8d-c2c50f5a2b83

