### PR TITLE
Fixing the functionality of the Floating Action Button (FAB) to navig…

### DIFF
--- a/unischedule/lib/routes/shell_routes.dart
+++ b/unischedule/lib/routes/shell_routes.dart
@@ -23,18 +23,26 @@ Widget _getAppShell(BuildContext context, GoRouterState state, Widget child) {
   String appBarTitle = '';
   Color appBarColor = ColorConstants.white;
   bool useFAB = false;
+  VoidCallback? fabAction;
+
   switch(state.topRoute?.path) {
     case RouteConstants.calendar:
       appBarTitle = 'April';  // TODO implement dynamic month
       useFAB = true;
+      fabAction = () => context.push(RouteConstants.newEvent);
+      break;
     case RouteConstants.friends:
       appBarTitle = StringConstants.friendsTitle;
       appBarColor = ColorConstants.black;
       useFAB = true;
+      fabAction = null;
+      break;
     case RouteConstants.groups:
       appBarTitle = StringConstants.groupsTitle;
       appBarColor = ColorConstants.black;
       useFAB = true;
+      fabAction = null;// en un futuro podria ser: fabAction = () => context.push(RouteConstants.newEventCalendar);
+      break;
   }
 
   return UniScheduleAppShell(
@@ -43,6 +51,7 @@ Widget _getAppShell(BuildContext context, GoRouterState state, Widget child) {
     appBarTitle: appBarTitle,
     appBarColor: appBarColor,
     useFAB: useFAB,
+    fabAction: fabAction,
   );
 }
 

--- a/unischedule/lib/widgets/app_shell/app_fab_widget.dart
+++ b/unischedule/lib/widgets/app_shell/app_fab_widget.dart
@@ -4,15 +4,14 @@ import 'package:go_router/go_router.dart';
 import 'package:unischedule/constants/constants.dart';
 
 class UniScheduleFloatingActionButton extends StatelessWidget {
-  const UniScheduleFloatingActionButton({super.key});
+  final VoidCallback? onPressed;
+  const UniScheduleFloatingActionButton({super.key, this.onPressed});
 
   @override
   Widget build(BuildContext context) {
     return FloatingActionButton(
-      onPressed: () {
+      onPressed: onPressed,
         // TODO use a provider to automatically navigate depending on current route
-        context.push(RouteConstants.newEvent);
-      },
       backgroundColor: ColorConstants.white,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(10),

--- a/unischedule/lib/widgets/app_shell/app_shell_widget.dart
+++ b/unischedule/lib/widgets/app_shell/app_shell_widget.dart
@@ -19,11 +19,13 @@ class UniScheduleAppShell extends ConsumerStatefulWidget {
     required this.appBarTitle,
     required this.appBarColor,
     required this.useFAB,
+    required this.fabAction,
   });
   final Widget body;
   final String appBarTitle;
   final Color appBarColor;
   final bool useFAB;
+  final VoidCallback? fabAction;
 
   @override
   ConsumerState<UniScheduleAppShell> createState() => _UniScheduleAppShellState();
@@ -54,7 +56,7 @@ class _UniScheduleAppShellState extends ConsumerState<UniScheduleAppShell> {
       backgroundColor: ColorConstants.desertStorm,
       bottomNavigationBar: const UniScheduleBottomNavBar(),
       drawer: const UniScheduleDrawer(),
-      floatingActionButton: widget.useFAB ? const UniScheduleFloatingActionButton() : null,
+      floatingActionButton: widget.useFAB ?  UniScheduleFloatingActionButton(onPressed: widget.fabAction) : null,
       floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
     );
   }


### PR DESCRIPTION
## Description
This pull request addresses the following issues/improvements:

- Fixing the functionality of the Floating Action Button (FAB) to navigate to different routes depending on the current route or disable it temporarily when not needed.

## Changes Made
- Updated the `UniScheduleFloatingActionButton` widget in `app_fab_widget.dart` to accept a callback for the onPressed event, allowing for dynamic behavior based on the current route.
- Modified the `_getAppShell` function in `shell_routes.dart` to pass the correct action to the FAB based on the current route.


## Testing
- Tested the behavior of the FAB in different routes to ensure it navigates correctly or is disabled as expected.

## Video


https://github.com/ISIS3510-202410-Team-13/Flutter/assets/78111224/b531644f-d500-4a57-bc20-222cde2e18dd




