### PR TITLE
 Add Connectivity Status Icon to UniScheduleAppBar

### DIFF
--- a/unischedule/lib/constants/strings/asset_constants.dart
+++ b/unischedule/lib/constants/strings/asset_constants.dart
@@ -8,4 +8,6 @@ class AssetConstants {
   static const String icComment = 'assets/icons/comment.svg';
   static const String icMagnifyingGlass = 'assets/icons/magnifying-glass.svg';
   static const String icSquarePlus = 'assets/icons/square-plus.svg';
+  static const String icCloud = 'assets/icons/plane.svg';
+  static const String icCloudSlash = 'assets/icons/plane-slash.svg';
 }

--- a/unischedule/lib/widgets/app_shell/app_bar_widget.dart
+++ b/unischedule/lib/widgets/app_shell/app_bar_widget.dart
@@ -2,8 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
 import 'package:unischedule/constants/constants.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:unischedule/providers/providers.dart';
 
-class UniScheduleAppBar extends StatelessWidget implements PreferredSizeWidget {
+
+
+class UniScheduleAppBar extends ConsumerWidget implements PreferredSizeWidget {
   const UniScheduleAppBar({
     super.key,
     required this.color,
@@ -17,7 +21,8 @@ class UniScheduleAppBar extends StatelessWidget implements PreferredSizeWidget {
   Size get preferredSize => const Size.fromHeight(StyleConstants.appBarHeight);
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final connectivityStatus = ref.watch(connectivityStatusProvider);
     return AppBar(
       backgroundColor: ColorConstants.transparent,
       elevation: 0,
@@ -39,6 +44,12 @@ class UniScheduleAppBar extends StatelessWidget implements PreferredSizeWidget {
         },
       ),
       actions: <Widget>[
+        // Add Non-clickable Connectivity Icon
+        if (connectivityStatus == ConnectivityStatus.isDisconnected) // Assuming true means online
+    Icon(Icons.wifi_off,color: color,size: 28,)
+        else
+        Icon(Icons.wifi,color: color,size: 28,),
+        // Existing Notification Button
         IconButton(
           icon: SvgPicture.asset(
             AssetConstants.icBell,
@@ -51,6 +62,8 @@ class UniScheduleAppBar extends StatelessWidget implements PreferredSizeWidget {
           },
         ),
       ],
+
+
     );
   }
 }


### PR DESCRIPTION
## Description:

This pull request introduces a dynamic connectivity status icon to the UniScheduleAppBar component. The icon reflects the current network connection state (online or offline) using flutter_riverpod and the connectivityStatusProvider.

## Changes:

- Dependency Addition: Added flutter_riverpod as a dependency to manage application state.
- Provider Inclusion: Imported connectivityStatusProvider from the providers.dart file.
- ConsumerWidget: Converted UniScheduleAppBar to a ConsumerWidget to access the provider's value.
- Connectivity Status Access: In the build method, retrieved the connectivityStatus from the provider using ref.watch(connectivityStatusProvider).
- Conditional Icon Rendering: Within the actions section of the AppBar, implemented conditional rendering using an if statement:
  - If connectivityStatus is ConnectivityStatus.isDisconnected (assuming true indicates offline), an Icon with Icons.wifi_off is displayed.
  - Otherwise, an Icon with Icons.wifi is displayed.
- Icon Styling: Ensured consistent styling for the connectivity icon by setting its color (color) to match the app bar's overall color scheme.

## Testing:

Manually tested the connectivity icon on different network conditions (online/offline) to verify its dynamic update behavior.
Consider adding unit tests (if applicable) to ensure the icon's functionality across different scenarios.
## Benefits:

Provides users with real-time network status information directly within the app bar.
Enhances user experience by keeping them informed about their connectivity.

## Video:


https://github.com/ISIS3510-202410-Team-13/Flutter/assets/78111224/da1154ba-67cb-4a2f-8059-30b0fd8b2bdf

