### PR TITLE
Now the events that has a different day at start and end are rendered

### DIFF
--- a/unischedule/lib/views/calendar/widgets/calendar_event.dart
+++ b/unischedule/lib/views/calendar/widgets/calendar_event.dart
@@ -34,7 +34,7 @@ class CalendarEvent extends StatelessWidget {
     final dayOffset = dayOfWeek - 1;
 
     final fullWidth = MediaQuery.of(context).size.width - 80; // 30 offset + (25 + 25) padding
-    final fullHeight = (endHour-startHour) * (500/(endHour-startHour)+10);  // Each hour 10 text + 60 sized box
+    final fullHeight = (endHour-startHour) * (425/(endHour-startHour)+10);  // Each hour 10 text + 60 sized box
 
     final boxWidth = fullWidth / 7;
     final boxHeight = fullHeight * duration / (endHour-startHour);

--- a/unischedule/lib/views/calendar/widgets/calendar_time_lines.dart
+++ b/unischedule/lib/views/calendar/widgets/calendar_time_lines.dart
@@ -17,7 +17,7 @@ Widget build(BuildContext context) {
   return Column(
     children: List.generate((endHour - startHour + 1) * 2, (index) {
       if (index == 0) return const SizedBox(height: 6);
-      if (index % 2 == 0) return SizedBox(height: 500/(endHour - startHour) * 1);
+      if (index % 2 == 0) return SizedBox(height: 425/(endHour - startHour) * 1);
 
       final time = '${startHour + index ~/ 2}:00';
       return Row(


### PR DESCRIPTION
The bug related to not render the events which day of startDate and day of endDate were different was fixed. Now it works properly. Here you can see a video:

https://github.com/ISIS3510-202410-Team-13/Flutter/assets/69651671/798d2f49-cc88-4766-9cc8-a413371eb0e4

closes #117 