### PR TITLE
139 local storage for notifications

### DIFF
--- a/unischedule/lib/constants/http/http_constants.dart
+++ b/unischedule/lib/constants/http/http_constants.dart
@@ -15,4 +15,7 @@ class HTTPConstants {
 
   // FEATURE ANALYTICS
   static const String FEATURE_ANALYTICS_BASE_URL = 'https://unischedule-5ee93.uc.r.appspot.com/';
+
+    // NOTIFICATIONS
+  static const String NOTIFICATIONS_BASE_URL = 'https://unischedule-5ee93.uc.r.appspot.com/';
 }

--- a/unischedule/lib/constants/strings/local_storage_constants.dart
+++ b/unischedule/lib/constants/strings/local_storage_constants.dart
@@ -4,10 +4,12 @@ class LocalStorageConstants {
   static const int eventModelTypeId = 2;
   static const int eventSyncModelTypeId = 2;
   static const int groupModelTypeId = 3;
+  static const int notificationModelTypeId = 4;
 
   // Box names
   static const String friendBox = 'friendBox';
   static const String groupBox = 'groupBox';
   static const String eventBox = 'eventBox';
   static const String eventSyncBox = 'eventSyncBox';
+  static const String notificationBox = 'notificationBox';
 }

--- a/unischedule/lib/models/models.dart
+++ b/unischedule/lib/models/models.dart
@@ -2,4 +2,4 @@ export 'available_spaces/available_spaces_model.dart';
 export 'groups/group_model.dart';
 export 'friends/friend_model.dart';
 export 'events/event_model.dart';
-export 'notifications/notification.dart';
+export 'notifications/notification_model.dart';

--- a/unischedule/lib/models/notifications/notification.dart
+++ b/unischedule/lib/models/notifications/notification.dart
@@ -1,44 +1,45 @@
 // lib/models/notification.dart
 class Notification {
+  final String id;  // Agregar el campo id
   final String timeAgo;
   final String imageUrl;
   final String type;
   final bool viewed;
 
-  Notification(this.timeAgo, this.imageUrl, this.type, this.viewed);
+  Notification(this.id, this.timeAgo, this.imageUrl, this.type, this.viewed);
 }
 
 class FriendRequestNotification extends Notification {
   final String userName;
-  FriendRequestNotification(this.userName, String timeAgo, String imageUrl, bool viewed)
-      : super(timeAgo, imageUrl, 'FriendRequest', viewed);
+  FriendRequestNotification(this.userName, String id, String timeAgo, String imageUrl, bool viewed)
+      : super(id, timeAgo, imageUrl, 'FriendRequest', viewed);
 }
 
 class MessageNotification extends Notification {
   final String friendName;
   final String message;
-  MessageNotification(this.friendName, this.message, String timeAgo, String imageUrl, bool viewed)
-      : super(timeAgo, imageUrl, 'Message', viewed);
+  MessageNotification(this.friendName, this.message, String id, String timeAgo, String imageUrl, bool viewed)
+      : super(id, timeAgo, imageUrl, 'Message', viewed);
 }
 
 class NewFeatureNotification extends Notification {
   final String title;
   final String description;
-  NewFeatureNotification(this.title, this.description, String timeAgo, String imageUrl, bool viewed)
-      : super(timeAgo, imageUrl, 'NewFeature', viewed);
+  NewFeatureNotification(this.title, this.description, String id, String timeAgo, String imageUrl, bool viewed)
+      : super(id, timeAgo, imageUrl, 'NewFeature', viewed);
 }
 
 class FileSharedNotification extends Notification {
   final String friendName;
   final String fileName;
   final String fileSize;
-  FileSharedNotification(this.friendName, this.fileName, this.fileSize, String timeAgo, String imageUrl, bool viewed)
-      : super(timeAgo, imageUrl, 'FileShared', viewed);
+  FileSharedNotification(this.friendName, this.fileName, this.fileSize, String id, String timeAgo, String imageUrl, bool viewed)
+      : super(id, timeAgo, imageUrl, 'FileShared', viewed);
 }
 
 class GroupJoinedNotification extends Notification {
   final String friendName;
   final String groupName;
-  GroupJoinedNotification(this.friendName, this.groupName, String timeAgo, String imageUrl, bool viewed)
-      : super(timeAgo, imageUrl, 'GroupJoined', viewed);
+  GroupJoinedNotification(this.friendName, this.groupName, String id, String timeAgo, String imageUrl, bool viewed)
+      : super(id, timeAgo, imageUrl, 'GroupJoined', viewed);
 }

--- a/unischedule/lib/models/notifications/notification_model.dart
+++ b/unischedule/lib/models/notifications/notification_model.dart
@@ -1,0 +1,21 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:hive/hive.dart';
+import 'package:unischedule/constants/constants.dart';
+
+part 'notification_model.freezed.dart';
+part 'notification_model.g.dart';
+
+@freezed
+@HiveType(typeId: LocalStorageConstants.notificationModelTypeId)
+class NotificationModel with _$NotificationModel {
+  const factory NotificationModel({
+    @HiveField(0) required String id,
+    @HiveField(1) required String title,
+    @HiveField(3) required String description,
+    @HiveField(4) required String timeAgo,
+    @HiveField(5) required String imageUrl,
+    @HiveField(6) required bool viewed,
+  }) = _NotificationModel;
+
+  factory NotificationModel.fromJson(Map<String, dynamic> json) => _$NotificationModelFromJson(json);
+}

--- a/unischedule/lib/providers/notifications/notifications_provider.dart
+++ b/unischedule/lib/providers/notifications/notifications_provider.dart
@@ -1,0 +1,15 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:unischedule/models/models.dart';
+import 'package:unischedule/models/notifications/notification_model.dart';
+import 'package:unischedule/repositories/repositories.dart';
+
+part 'notifications_provider.g.dart';
+
+// TODO add here all use cases as functions
+@riverpod
+Future<List<NotificationModel>> fetchNotifications(FetchNotificationsRef ref) {
+  final notificationsRepository = ref.watch(notificationsRepositoryProvider);
+  ref.keepAlive();
+
+  return notificationsRepository.fetchNotifications();
+}

--- a/unischedule/lib/providers/providers.dart
+++ b/unischedule/lib/providers/providers.dart
@@ -3,5 +3,6 @@ export 'available_spaces/available_spaces_provider.dart';
 export 'events/events_provider.dart';
 export 'friends/friends_provider.dart';
 export 'groups/groups_provider.dart';
+export 'notifications/notifications_provider.dart';
 export 'connectivity/connectivity_provider.dart';
 export 'feature_analytics/feature_analytics_provider.dart';

--- a/unischedule/lib/repositories/notifications/notifications_repository.dart
+++ b/unischedule/lib/repositories/notifications/notifications_repository.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:unischedule/models/notifications/notification_model.dart';
+import 'package:unischedule/constants/constants.dart';
+import 'package:unischedule/services/services.dart';
+import 'package:unischedule/providers/providers.dart';
+
+part 'notifications_repository.g.dart';
+
+abstract class NotificationsRepository {
+  Future<List<NotificationModel>> fetchNotifications();
+  Future<void> saveNotification(NotificationModel notification);
+}
+
+class NotificationsRepositoryImpl extends NotificationsRepository {
+
+  final DioApiService client;
+  final HiveBoxService<NotificationModel> boxService;
+  final Ref ref;
+
+  NotificationsRepositoryImpl({
+    required this.ref,
+    required this.client,
+    required this.boxService,
+  });
+
+  @override
+  Future<List<NotificationModel>> fetchNotifications() async {
+
+    List<NotificationModel> notifications = boxService.getAll();
+
+    return notifications;
+  }
+
+  @override
+  Future<void> saveNotification(NotificationModel notification) async {
+    await boxService.put(notification.id, notification);
+  }
+}
+
+
+@riverpod
+NotificationsRepositoryImpl notificationsRepository(NotificationsRepositoryRef ref) {
+  return NotificationsRepositoryImpl(
+    ref: ref,
+    client: DioApiServiceFactory.getService(HTTPConstants.NOTIFICATIONS_BASE_URL),
+    boxService: HiveBoxServiceFactory.notificationModelBox,
+  );
+}

--- a/unischedule/lib/repositories/repositories.dart
+++ b/unischedule/lib/repositories/repositories.dart
@@ -3,3 +3,4 @@ export 'events/events_repository.dart';
 export 'friends/friends_repository.dart';
 export 'groups/groups_repository.dart';
 export 'feature_analytics/feature_analytics_repository.dart';
+export 'notifications/notifications_repository.dart';

--- a/unischedule/lib/services/local_storage/hive_box_service.dart
+++ b/unischedule/lib/services/local_storage/hive_box_service.dart
@@ -8,6 +8,7 @@ class HiveBoxServiceFactory {
   static late final HiveBoxService<EventModel> eventModelBox;
   static late final HiveBoxService<EventModel> eventSyncModelBox;
   static late final HiveBoxService<GroupModel> groupModelBox;
+  static late final HiveBoxService<NotificationModel> notificationModelBox;
 
   static Future<void> initHive() async {
     await Hive.initFlutter();
@@ -15,23 +16,26 @@ class HiveBoxServiceFactory {
     Hive.registerAdapter(FriendModelAdapter());
     Hive.registerAdapter(EventModelAdapter());
     Hive.registerAdapter(GroupModelAdapter());
+    Hive.registerAdapter(NotificationModelAdapter());
 
     await Hive.openBox<FriendModel>(LocalStorageConstants.friendBox);
     await Hive.openBox<EventModel>(LocalStorageConstants.eventBox);
     await Hive.openBox<EventModel>(LocalStorageConstants.eventSyncBox);
     await Hive.openBox<GroupModel>(LocalStorageConstants.groupBox);
+    await Hive.openBox<NotificationModel>(LocalStorageConstants.notificationBox);
 
     friendModelBox = HiveBoxService(LocalStorageConstants.friendBox);
     eventModelBox = HiveBoxService(LocalStorageConstants.eventBox);
-
     eventSyncModelBox = HiveBoxService(LocalStorageConstants.eventSyncBox);
     groupModelBox = HiveBoxService(LocalStorageConstants.groupBox);
+    notificationModelBox = HiveBoxService(LocalStorageConstants.notificationBox);
   }
 
   static Future<void> resetHive() async {
     await friendModelBox.clear();
     await eventModelBox.clear();
     await groupModelBox.clear();
+    await notificationModelBox.clear();
   }
 }
 

--- a/unischedule/lib/views/notifications/widgets/notifications_app_bar.dart
+++ b/unischedule/lib/views/notifications/widgets/notifications_app_bar.dart
@@ -1,48 +1,74 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:unischedule/constants/constants.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:unischedule/providers/providers.dart';
+import 'package:unischedule/models/notifications/notification_model.dart';
 
-class NotificationsAppBar extends ConsumerStatefulWidget implements PreferredSizeWidget {
-  const NotificationsAppBar({super.key});
+class UniScheduleAppBar extends ConsumerWidget implements PreferredSizeWidget {
+  const UniScheduleAppBar({
+    super.key,
+    required this.color,
+    required this.title,
+  });
 
-  @override
-  ConsumerState<NotificationsAppBar> createState() => _NotificationsAppBarState();
+  final Color color;
+  final String title;
 
   @override
   Size get preferredSize => const Size.fromHeight(StyleConstants.appBarHeight);
-}
-
-class _NotificationsAppBarState extends ConsumerState<NotificationsAppBar> {
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final connectivityStatus = ref.watch(connectivityStatusProvider);
+    final allNotificationsFuture = ref.watch(fetchNotificationsProvider);
+
     return AppBar(
       backgroundColor: ColorConstants.transparent,
       elevation: 0,
-      centerTitle: true,
+      title: Text(
+        title,
+        style: Theme.of(context).textTheme.titleMedium?.copyWith(
+          color: color,
+        ),
+      ),
       leading: IconButton(
         icon: SvgPicture.asset(
-            'assets/icons/arrow-left.svg', // TODO use AssetConstants
-            width: 21, // TODO use StyleConstants
-            height: 24,  // TODO use StyleConstants
-            color: ColorConstants.black
+          AssetConstants.icBars,
+          width: StyleConstants.iconWidth,
+          height: StyleConstants.iconHeight,
+          color: color,
         ),
         onPressed: () {
-          context.pop();
+          Scaffold.of(context).openDrawer();
         },
       ),
-      title: const Text(
-        'Notifications', // TODO use StringConstants
-        style: TextStyle( // TODO use text theme
-          fontFamily: 'Poppins',
-          fontSize: 24,
-          fontWeight: FontWeight.bold,
-          color: ColorConstants.black,
+      actions: <Widget>[
+        // Add Non-clickable Connectivity Icon
+        if (connectivityStatus == ConnectivityStatus.isDisconnected)
+          Icon(Icons.wifi_off, color: color, size: 28)
+        else
+          Icon(Icons.wifi, color: color, size: 28),
+        // Existing Notification Button
+        allNotificationsFuture.when(
+          data: (notifications) {
+            final unreadCount = notifications.where((n) => !n.viewed).length;
+            return IconButton(
+              icon: Icon(
+                unreadCount >= 1 ? Icons.notifications_active : Icons.notifications,
+                color: color,
+                size: 28,
+              ),
+              onPressed: () {
+                context.push(RouteConstants.notifications);
+              },
+            );
+          },
+          loading: () => Icon(Icons.notifications, color: color, size: 28),
+          error: (err, stack) => Icon(Icons.error, color: color, size: 28),
         ),
-        textAlign: TextAlign.start,
-      ),
+      ],
     );
   }
 }

--- a/unischedule/lib/widgets/app_shell/app_bar_widget.dart
+++ b/unischedule/lib/widgets/app_shell/app_bar_widget.dart
@@ -5,8 +5,6 @@ import 'package:unischedule/constants/constants.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:unischedule/providers/providers.dart';
 
-
-
 class UniScheduleAppBar extends ConsumerWidget implements PreferredSizeWidget {
   const UniScheduleAppBar({
     super.key,
@@ -23,6 +21,8 @@ class UniScheduleAppBar extends ConsumerWidget implements PreferredSizeWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final connectivityStatus = ref.watch(connectivityStatusProvider);
+    final allNotificationsFuture = ref.watch(fetchNotificationsProvider);
+
     return AppBar(
       backgroundColor: ColorConstants.transparent,
       elevation: 0,
@@ -34,10 +34,10 @@ class UniScheduleAppBar extends ConsumerWidget implements PreferredSizeWidget {
       ),
       leading: IconButton(
         icon: SvgPicture.asset(
-            AssetConstants.icBars,
-            width: StyleConstants.iconWidth,
-            height: StyleConstants.iconHeight,
-            color: color,
+          AssetConstants.icBars,
+          width: StyleConstants.iconWidth,
+          height: StyleConstants.iconHeight,
+          color: color,
         ),
         onPressed: () {
           Scaffold.of(context).openDrawer();
@@ -45,25 +45,29 @@ class UniScheduleAppBar extends ConsumerWidget implements PreferredSizeWidget {
       ),
       actions: <Widget>[
         // Add Non-clickable Connectivity Icon
-        if (connectivityStatus == ConnectivityStatus.isDisconnected) // Assuming true means online
-    Icon(Icons.wifi_off,color: color,size: 28,)
+        if (connectivityStatus == ConnectivityStatus.isDisconnected)
+          Icon(Icons.wifi_off, color: color, size: 28)
         else
-        Icon(Icons.wifi,color: color,size: 28,),
+          Icon(Icons.wifi, color: color, size: 28),
         // Existing Notification Button
-        IconButton(
-          icon: SvgPicture.asset(
-            AssetConstants.icBell,
-            width: StyleConstants.iconWidth,
-            height: StyleConstants.iconHeight,
-            color: color,
-          ),
-          onPressed: () {
-            context.push(RouteConstants.notifications);
+        allNotificationsFuture.when(
+          data: (notifications) {
+            final unreadCount = notifications.where((n) => !n.viewed).length;
+            return IconButton(
+              icon: Icon(
+                unreadCount >= 1 ? Icons.notifications_active : Icons.notifications,
+                color: color,
+                size: 28,
+              ),
+              onPressed: () {
+                context.push(RouteConstants.notifications);
+              },
+            );
           },
+          loading: () => Icon(Icons.notifications, color: color, size: 28),
+          error: (err, stack) => Icon(Icons.error, color: color, size: 28),
         ),
       ],
-
-
     );
   }
 }


### PR DESCRIPTION
## Pull Request: Enhanced Notification Handling with Local Storage Integration

### Summary
This pull request primarily focuses on enhancing the notification handling system by integrating robust local storage capabilities using Hive. Additional improvements to the user interface have also been made to support these changes. The following key updates are included:

### Key Changes
1. **Local Storage Integration for Notifications**:
    - Implemented the functionality to save incoming notifications to local storage using Hive.
    - Modified the notification models to ensure compatibility with Hive.
    - Ensured notifications are saved to Hive upon receipt and can be retrieved efficiently.

2. **Notification Models Update**:
    - Added `id` field to the notification model in `notification.dart` to match the `notification_model.dart` structure and enable unique identification of notifications.
    - Ensured `viewed` is correctly handled as a `bool` type.

3. **Notifications Provider**:
    - Created a provider to fetch and manage notifications from Hive local storage, enabling dynamic updates to the notification list.

4. **AppBar Widget**:
    - Modified the `UniScheduleAppBar` to dynamically update the notification icon based on the presence of unread notifications, using Riverpod to watch and respond to changes in notification state.

5. **Notifications View**:
    - Updated the `NotificationsView` to display unread notifications first and allow marking them as read.
    - Inverted the order of the notification list to show the newest notifications at the top.
    - Adjusted the order of the tabs to show "Unread" first, followed by "All".

6. **Main Application Entry**:
    - Integrated notification handling in `main.dart` to save incoming notifications to local storage and update the UI accordingly.

### Files Changed
- `lib/main.dart`
- `lib/models/notifications/notification.dart`
- `lib/models/notifications/notification_model.dart`
- `lib/providers/notifications_provider.dart`
- `lib/providers/providers.dart`
- `lib/repositories/notifications/notifications_repository.dart`
- `lib/repositories/repositories.dart`
- `lib/services/hive_box_service.dart`
- `lib/views/notifications/notifications_view.dart`
- `lib/widgets/app_shell/app_bar_widget.dart`



### Video

https://github.com/ISIS3510-202410-Team-13/Flutter/assets/78111224/b97ca199-e98b-45f5-b397-804de19dcdf4



### Additional Notes
- The `timeAgo` field in notifications is currently a placeholder and should be implemented for accurate time sorting.


Please review the changes and provide feedback or approval for merging into the `develop` branch.
